### PR TITLE
mise.tomlの.gitignore指定ファイル名を修正

### DIFF
--- a/.gitignore_global
+++ b/.gitignore_global
@@ -1,3 +1,3 @@
 .DS_Store
 .envrc
-.mise.toml
+mise.toml


### PR DESCRIPTION
`mise.toml`が正しい

from https://mise.jdx.dev/configuration.html

<img width="785" alt="スクリーンショット 2025-02-22 19 03 32" src="https://github.com/user-attachments/assets/b3d5ff75-1d08-4044-85ff-4a8ad0fdd643" />
