### PR TITLE
Makefileを追加

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,13 @@
+.PHONY: install update sync help
+
+help: ## Show this help
+	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-15s\033[0m %s\n", $$1, $$2}'
+
+install: ## Run install.sh to setup dotfiles
+	./install.sh
+
+update: ## Update Homebrew packages from Brewfile
+	brew bundle --file=Brewfile
+
+sync: ## Sync current Homebrew packages to Brewfile
+	brew bundle dump --force --file=Brewfile


### PR DESCRIPTION
## Summary
- よく使う操作をMakefileでタスク化
- `make help`でコマンド一覧を表示

## 追加されるコマンド
| コマンド | 説明 |
|----------|------|
| `make install` | dotfilesのセットアップ（install.sh実行） |
| `make update` | Homebrewパッケージの更新 |
| `make sync` | 現在のHomebrewパッケージをBrewfileに同期 |
| `make help` | ヘルプ表示 |

## Test plan
- [x] `make help` の動作確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)