### PR TITLE
WezTermの設定を更新

### DIFF
--- a/packages/wezterm/.wezterm.lua
+++ b/packages/wezterm/.wezterm.lua
@@ -27,7 +27,7 @@ config.keys = {
     action=wezterm.action{SendString="\x1b\r"}
   },
   {
-    key = '-',
+    key = '\\',
     mods = 'CMD',
     action = wezterm.action.SplitVertical { domain = 'CurrentPaneDomain' },
   },


### PR DESCRIPTION
## Summary
- 垂直分割のキーバインドを`CMD + -`から`CMD + \`に変更（水平分割の`CMD + |`と対になるように）

## Test plan
- [ ] WezTermを再起動して設定が反映されることを確認
- [ ] `CMD + \`で垂直分割が動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)