### PR TITLE
WeztermのカラースキームをTwilight (light)に変更

### DIFF
--- a/packages/wezterm/.wezterm.lua
+++ b/packages/wezterm/.wezterm.lua
@@ -7,7 +7,7 @@ if wezterm.config_builder then
 end
 
 -- see https://leaysgur.github.io/wezterm-colorscheme/
-config.color_scheme = 'Default (dark) (terminal.sexy)'
+config.color_scheme = 'Twilight (light) (terminal.sexy)'
 
 config.font = wezterm.font_with_fallback {
   { family = "Moralerspace Argon", assume_emoji_presentation = true }


### PR DESCRIPTION
## Summary
- Weztermのカラースキームを `Default (dark) (terminal.sexy)` から `Twilight (light) (terminal.sexy)` に変更

## Test plan
- [ ] Weztermを再起動してカラースキームが適用されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)