### PR TITLE
Weztermに透明度を追加

### DIFF
--- a/packages/wezterm/.wezterm.lua
+++ b/packages/wezterm/.wezterm.lua
@@ -43,5 +43,7 @@ config.keys = {
   },
 }
 config.window_close_confirmation = 'NeverPrompt'
+config.window_background_opacity = 0.9
+config.macos_window_background_blur = 20
 
 return config


### PR DESCRIPTION
## Summary
- Weztermウィンドウに透明度を追加（10%透明）
- macOS向けの背景ぼかし効果を追加

## Test plan
- [ ] weztermを再起動して透明度が適用されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)