### PR TITLE
WezTermの背景透明度をフルスクリーン状態で動的に切り替え

### DIFF
--- a/packages/wezterm/.wezterm.lua
+++ b/packages/wezterm/.wezterm.lua
@@ -43,7 +43,20 @@ config.keys = {
   },
 }
 config.window_close_confirmation = 'NeverPrompt'
-config.window_background_opacity = 0.9
+config.window_background_opacity = 0.5
 config.macos_window_background_blur = 20
+
+wezterm.on('window-resized', function(window, pane)
+  local overrides = window:get_config_overrides() or {}
+  local dimensions = window:get_dimensions()
+
+  if dimensions.is_full_screen then
+    overrides.window_background_opacity = 1
+  else
+    overrides.window_background_opacity = 0.5
+  end
+
+  window:set_config_overrides(overrides)
+end)
 
 return config


### PR DESCRIPTION
## Summary
- フルスクリーン時は背景を不透明(opacity=1)に設定
- 通常ウィンドウ時は背景を半透明(opacity=0.5)に設定
- `window-resized` イベントを使用して動的に切り替え

## Test plan
- [ ] WezTermを再起動
- [ ] 通常ウィンドウで背景が半透明であることを確認
- [ ] フルスクリーンに切り替えて不透明になることを確認
- [ ] フルスクリーン解除で半透明に戻ることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)