### PR TITLE
WezTermでネイティブmacOSフルスクリーンモードを有効化

### DIFF
--- a/packages/wezterm/.wezterm.lua
+++ b/packages/wezterm/.wezterm.lua
@@ -45,6 +45,7 @@ config.keys = {
 config.window_close_confirmation = 'NeverPrompt'
 config.window_background_opacity = 0.5
 config.macos_window_background_blur = 20
+config.native_macos_fullscreen_mode = true
 
 wezterm.on('window-resized', function(window, pane)
   local overrides = window:get_config_overrides() or {}


### PR DESCRIPTION
## 概要

WezTermの`native_macos_fullscreen_mode`を有効化し、macOS標準のフルスクリーンアニメーションを使用するように設定。

## 変更内容

- `config.native_macos_fullscreen_mode = true` を追加

## 効果

- Mission Controlとの統合が自然になる
- macOS標準のフルスクリーン遷移アニメーションが適用される

🤖 Generated with [Claude Code](https://claude.ai/code)