### PR TITLE
WezTermのウィンドウ初期サイズを設定

### DIFF
--- a/packages/wezterm/.wezterm.lua
+++ b/packages/wezterm/.wezterm.lua
@@ -46,6 +46,8 @@ config.window_close_confirmation = 'NeverPrompt'
 config.window_background_opacity = 0.5
 config.macos_window_background_blur = 20
 config.native_macos_fullscreen_mode = true
+config.initial_cols = 120
+config.initial_rows = 40
 
 wezterm.on('window-resized', function(window, pane)
   local overrides = window:get_config_overrides() or {}


### PR DESCRIPTION
## 概要

WezTermの起動時のウィンドウサイズを固定値に設定。

## 変更内容

- `initial_cols = 120` (横幅120文字)
- `initial_rows = 40` (縦40行)

## 効果

- 毎回同じサイズでウィンドウが起動するため、画面配置が安定する

🤖 Generated with [Claude Code](https://claude.ai/code)