### PR TITLE
自作 Claude Code スキルを dotfiles で管理できるようにする

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
-.PHONY: install update sync link unlink setup-mcp help
+.PHONY: install update sync link unlink setup-mcp setup-skills help
 
-PACKAGES := zsh vim tmux wezterm git npm starship yazi claude codex
+PACKAGES := zsh vim tmux wezterm git npm starship yazi claude codex claude-skills
 
 help: ## Show this help
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-15s\033[0m %s\n", $$1, $$2}'
@@ -15,7 +15,7 @@ sync: ## Sync current Homebrew packages to Brewfile
 	brew bundle dump --force --file=Brewfile
 
 link: ## Create symlinks with stow
-	@mkdir -p ~/.config/yazi ~/.claude ~/.codex
+	@mkdir -p ~/.config/yazi ~/.claude ~/.codex ~/.claude/plugins/repos
 	cd packages && stow -v -t ~ $(PACKAGES)
 
 unlink: ## Remove symlinks with stow
@@ -24,3 +24,7 @@ unlink: ## Remove symlinks with stow
 setup-mcp: ## Setup MCP servers for Claude Code
 	-claude mcp add --scope user --transport stdio chrome-devtools -- npx chrome-devtools-mcp@latest
 	-claude mcp add --scope user --transport stdio playwright -- npx @playwright/mcp@latest
+
+setup-skills: ## Setup custom Claude Code skills
+	-claude plugin marketplace add $(HOME)/.claude/plugins/repos/my-skills
+	-claude plugin install langfuse@my-skills --scope user

--- a/packages/claude-skills/.claude/plugins/repos/my-skills/.claude-plugin/marketplace.json
+++ b/packages/claude-skills/.claude/plugins/repos/my-skills/.claude-plugin/marketplace.json
@@ -1,0 +1,18 @@
+{
+  "name": "my-skills",
+  "owner": {
+    "name": "hirokisakabe"
+  },
+  "metadata": {
+    "description": "Personal skill collection",
+    "version": "1.0.0"
+  },
+  "plugins": [
+    {
+      "name": "langfuse",
+      "source": "./plugins/langfuse",
+      "description": "Langfuse トレース取得スキル",
+      "version": "1.0.0"
+    }
+  ]
+}

--- a/packages/claude-skills/.claude/plugins/repos/my-skills/plugins/langfuse/.claude-plugin/plugin.json
+++ b/packages/claude-skills/.claude/plugins/repos/my-skills/plugins/langfuse/.claude-plugin/plugin.json
@@ -1,0 +1,8 @@
+{
+  "name": "langfuse",
+  "version": "1.0.0",
+  "description": "Langfuse のトレース、ログ、observability データを取得・表示する",
+  "author": {
+    "name": "hirokisakabe"
+  }
+}

--- a/packages/claude-skills/.claude/plugins/repos/my-skills/plugins/langfuse/skills/langfuse/SKILL.md
+++ b/packages/claude-skills/.claude/plugins/repos/my-skills/plugins/langfuse/skills/langfuse/SKILL.md
@@ -1,0 +1,66 @@
+---
+name: langfuse
+description: Langfuseのトレース、ログ、observability、モニタリングデータを取得・表示する。ユーザーが「Langfuseのログを見せて」「トレースを確認」「観測データを取得」などと言ったときに使用する。
+---
+
+# Langfuse Traces Skill
+
+Langfuse APIからトレースログを取得して表示する。
+
+## パラメータ
+
+- `limit`: 取得件数（デフォルト: 5）
+- `environment`: フィルタする環境（production / development）
+
+例:
+
+- `/langfuse` - 直近5件を取得
+- `/langfuse 10` - 直近10件を取得
+- `/langfuse production` - production環境のみ
+
+## 実行手順
+
+1. 以下のNode.jsコードを実行してトレースを取得:
+
+```javascript
+require("dotenv").config();
+const publicKey = process.env.LANGFUSE_PUBLIC_KEY;
+const secretKey = process.env.LANGFUSE_SECRET_KEY;
+const baseUrl = process.env.LANGFUSE_BASE_URL;
+
+const auth = Buffer.from(publicKey + ":" + secretKey).toString("base64");
+const limit = ${LIMIT}; // パラメータから取得
+
+fetch(baseUrl + "/api/public/traces?limit=" + limit, {
+  headers: { "Authorization": "Basic " + auth }
+})
+.then(r => r.json())
+.then(data => console.log(JSON.stringify(data, null, 2)))
+.catch(e => console.error("Error:", e));
+```
+
+2. 取得結果を以下の形式でサマリー表示:
+
+| 時刻 | 環境 | ユーザー入力 | レイテンシ | コスト |
+| ---- | ---- | ------------ | ---------- | ------ |
+| ...  | ...  | ...          | ...        | ...    |
+
+3. 追加情報として以下も表示:
+   - 総トレース数（meta.totalItems）
+   - 取得したトレースのID一覧
+
+## 詳細取得
+
+特定のトレースの詳細を見たい場合は、トレースIDを指定して以下のエンドポイントを呼び出す:
+
+```
+GET /api/public/traces/{traceId}
+```
+
+## 環境変数
+
+以下の環境変数が `.env` に設定されている必要がある:
+
+- `LANGFUSE_PUBLIC_KEY`
+- `LANGFUSE_SECRET_KEY`
+- `LANGFUSE_BASE_URL`


### PR DESCRIPTION
## Summary

- 自作 Claude Code スキルを dotfiles リポジトリで管理し、Stow + Makefile で他のマシンでも再現可能にした
- Langfuse トレース取得スキルを追加

## 変更内容

- `packages/claude-skills/` に自作スキル用のローカルマーケットプレイスを追加
- `Makefile` に `setup-skills` ターゲットを追加
- `make link` で `~/.claude/plugins/repos/my-skills` にシンボリックリンクが作成される
- `make setup-skills` でスキルが登録される

## 使い方

```bash
# シンボリックリンク作成
make link

# スキル登録
make setup-skills
```

## 今後のスキル追加方法

1. `packages/claude-skills/.claude/plugins/repos/my-skills/plugins/<new-skill>/` を作成
2. `plugin.json` と `skills/<name>/SKILL.md` を配置
3. `marketplace.json` の `plugins` 配列に追加
4. `Makefile` の `setup-skills` ターゲットに `claude plugin install` 行を追加

## Test plan

- [x] `make link` でシンボリックリンクが作成されることを確認
- [x] `make setup-skills` でスキルが登録されることを確認
- [x] `claude plugin list` で `langfuse@my-skills` が表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)