### PR TITLE
agent-browser を mise のデフォルト npm パッケージに追加

### DIFF
--- a/packages/npm/.default-npm-packages
+++ b/packages/npm/.default-npm-packages
@@ -1,2 +1,3 @@
 # mise Default Node Packages
 @openai/codex
+agent-browser


### PR DESCRIPTION
## 概要

[agent-browser](https://github.com/vercel-labs/agent-browser) を mise のデフォルト npm パッケージに追加します。

agent-browser は AI エージェント向けのヘッドレスブラウザ自動化 CLI ツールです。

## 変更内容

- `packages/npm/.default-npm-packages` に `agent-browser` を追加

🤖 Generated with [Claude Code](https://claude.com/claude-code)