### PR TITLE
Asana デスクトップアプリ (cask) を削除

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -81,7 +81,6 @@ cask "microsoft-edge"
 cask "slack"
 cask "discord"
 cask "zoom"
-cask "asana"
 cask "miro"
 cask "figma"
 


### PR DESCRIPTION
## Summary
- cask `asana`（デスクトップアプリ）を Brewfile から削除
- CLI 版 `timwehrle/asana/asana` との名前衝突を解消

## 背景
cask と formula が同名のため、`brew bundle` 実行時に CLI 版のシンボリックリンクが作成されない問題があった。
デスクトップアプリは使用していないため削除で対応。

## Test plan
- [ ] `brew uninstall --cask asana` でデスクトップアプリを削除
- [ ] `brew link timwehrle/asana/asana` で CLI がリンクされることを確認
- [ ] `asana --version` で CLI が動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)