### PR TITLE
CLAUDE.mdにmake helpとclaude-skillsパッケージを追記

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,6 +9,9 @@ macOS 向けの dotfiles リポジトリ。Homebrew でパッケージ管理、G
 ## Commands
 
 ```bash
+# 利用可能なコマンド一覧を表示
+make help
+
 # 初回セットアップ（Homebrew インストール、パッケージインストール、シンボリックリンク作成）
 make install
 
@@ -41,6 +44,7 @@ packages/           # Stow パッケージ（各ツールの設定ファイル�
 ├── starship/      # .config/starship.toml
 ├── yazi/          # .config/yazi/yazi.toml
 ├── claude/        # .claude/settings.json, .claude/CLAUDE.md
+├── claude-skills/ # .claude/skills/ (Claude Code カスタムスキル)
 └── codex/         # .codex/AGENTS.md
 
 Brewfile           # Homebrew パッケージ定義


### PR DESCRIPTION
## Summary

- Commandsセクションに `make help` コマンドの説明を追加
- Architectureセクションに `claude-skills/` パッケージを追加

## 背景

既存のコードベースを確認したところ、以下の差異がありました：

1. Makefileに `help` ターゲットが存在するが、CLAUDE.mdに記載がなかった
2. `packages/claude-skills/` ディレクトリが存在し、Makefileの `PACKAGES` 変数にも含まれているが、CLAUDE.mdに記載がなかった

## Test plan

- [ ] `make help` コマンドが正常に動作することを確認
- [ ] ドキュメントの内容が実際のディレクトリ構造と一致していることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)