### PR TITLE
BrewfileにMonitorControlを追加

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -70,6 +70,7 @@ cask "inkscape"
 cask "raspberry-pi-imager"
 cask "logi-options+"
 cask "deepl"
+cask "monitorcontrol"
 
 # --- Fonts ---
 cask "font-hackgen-nerd"


### PR DESCRIPTION
## 概要

外部モニターの輝度・コントラスト調整ができるユーティリティアプリ MonitorControl を Brewfile に追加しました。

## 変更内容

- `cask "monitorcontrol"` を Utility Apps セクションに追加

🤖 Generated with [Claude Code](https://claude.ai/code)