### PR TITLE
Claude Codeの汎用パーミッションを追加

### DIFF
--- a/packages/claude/.claude/settings.json
+++ b/packages/claude/.claude/settings.json
@@ -36,6 +36,8 @@
       "WebFetch(domain:docs.firecrawl.dev)",
       "WebFetch(domain:www.firecrawl.dev)",
       "WebFetch(domain:serpapi.com)",
+      "WebFetch(domain:zenn.dev)",
+      "WebFetch(domain:python-pptx.readthedocs.io)",
       "WebSearch",
       "mcp__ide__executeCode",
       "mcp__playwright__browser_navigate",
@@ -63,6 +65,9 @@
       "Bash(convert:*)",
       "Bash(bun:*)",
       "Bash(env)",
+      "Bash(md5:*)",
+      "Bash(unzip:*)",
+      "Bash(pyftsubset:*)",
       "Skill(langfuse)"
     ],
     "deny": ["Read(./.env)", "Read(./.env.*)"],


### PR DESCRIPTION
## 概要

仕事用リポジトリ3つのClaude Code設定から、プロジェクト固有でない汎用的なパーミッションを取り込む。

## 変更内容

### Bashコマンド追加
- Python系: `uv`, `python3`, `pip3`, `pyftsubset`
- IaC系: `terraform`, `tflint`
- コンテナ/テスト: `docker`, `k6`
- Lint系: `actionlint`
- ユーティリティ: `command -v`, `xargs`, `test`, `convert`, `bun`, `env`, `md5`, `unzip`

### WebFetch
- `WebFetch(domain:*)` のワイルドカードが機能しないため、個別ドメイン指定に変更
- 追加ドメイン: github.com, npmjs.com, pypi.org, registry.terraform.io, grafana.com, sdk.vercel.ai, ai-sdk.dev, mastra.ai, langfuse.com, firecrawl.dev, serpapi.com, zenn.dev 等

### Playwright
- `browser_run_code`, `browser_network_requests` を追加

### スキル
- `Skill(langfuse)` を追加

## Test plan
- [ ] `make link` でシンボリックリンクを更新
- [ ] `~/.claude/settings.json` に正しく反映されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)