### PR TITLE
cwt (claude worktree) シェル関数を追加

### DIFF
--- a/packages/zsh/.zshrc
+++ b/packages/zsh/.zshrc
@@ -57,6 +57,7 @@ function cwt() {
     return 1
   fi
 
+  echo "ブランチ名を決定中..."
   local branch=$(claude -p "以下のタスクに適切なgitブランチ名を1つだけ出力して。命名規則: feature/xxx, fix/xxx, docs/xxx。英語ケバブケース。ブランチ名のみ出力。タスク: $task" | tr -d '`')
 
   if [ -z "$branch" ]; then


### PR DESCRIPTION
## Summary

- タスクの説明からブランチ名を決定し、git worktree作成、.envコピー、Claude対話セッション開始を一括で行う `cwt` シェル関数を `.zshrc` に追加
- 当初Claude Codeスキル(SKILL.md)として実装したが、スキルではworktree作成後のcd不可のため、シェル関数に変更

## 使い方

```bash
cwt ユーザー認証機能を追加
```

## Test plan

- [ ] `make link` でシンボリックリンクが正しく作成されることを確認
- [ ] `source ~/.zshrc` 後に `cwt` コマンドが利用可能であることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)