### PR TITLE
git wt-delete-merged エイリアスを追加

### DIFF
--- a/packages/git/.gitconfig
+++ b/packages/git/.gitconfig
@@ -4,6 +4,8 @@ email = hiroki.sakabe@icloud.com
 
 [alias]
 delete-merged = "!f () { git checkout $1; git branch --merged|egrep -v '\\*|develop|main'|xargs git branch -d; };f"
+# マージ済みブランチの worktree を削除してブランチも削除
+wt-delete-merged = "!f() { base=${1:-$(git config default.branch || echo main)}; merged=$(git branch --merged \"$base\" | sed 's/^[ *]*//' | grep -vE '^(main|develop)$'); if [ -z \"$merged\" ]; then echo \"No merged branches found.\"; return 0; fi; git worktree list --porcelain | awk '/^worktree /{wt=substr($0,10)} /^branch refs\\/heads\\//{b=substr($0,19); print wt \"|\" b}' | while IFS=\"|\" read -r wt_path branch_name; do if echo \"$merged\" | grep -qxF \"$branch_name\"; then echo \"Removing worktree: $wt_path (branch: $branch_name)\"; git worktree remove \"$wt_path\" && git branch -d \"$branch_name\"; fi; done; }; f"
 gg = "log --graph --pretty=oneline"
 # stash -> デフォルトブランチに移動 -> pull -> 元ブランチ削除 -> stash pop
 sdd = "!f() { CURRENT_BRANCH=$(git symbolic-ref --short HEAD); DEFAULT_BRANCH=$(git config default.branch); git stash; git checkout $DEFAULT_BRANCH; git pull; git branch -D $CURRENT_BRANCH; git stash pop; }; f"


### PR DESCRIPTION
## Summary
- `git delete-merged` の worktree 版として `git wt-delete-merged` エイリアスを追加
- マージ済みブランチに対応する worktree を検出し、worktree の削除とブランチの削除を行う

## 動作
1. ベースブランチ（デフォルト: `git config default.branch`）にマージ済みのブランチを取得
2. `git worktree list --porcelain` で全 worktree を列挙
3. マージ済みブランチの worktree を `git worktree remove` で削除し、`git branch -d` でブランチも削除
4. `main`、`develop` ブランチは保護対象として除外

## 使い方
```bash
# デフォルトブランチ（default.branch設定）に対してマージ済みのworktreeを削除
git wt-delete-merged

# 指定したブランチに対してマージ済みのworktreeを削除
git wt-delete-merged main
```

## Test plan
- [ ] `git wt-delete-merged` でマージ済み worktree が削除されること
- [ ] 未マージの worktree は削除されないこと
- [ ] 変更がある worktree は `git worktree remove` が安全に拒否すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)