### PR TITLE
feat: cwtでworktreeのsettings.local.jsonをmainへのシンボリックリンクにする

### DIFF
--- a/packages/zsh/.zshrc
+++ b/packages/zsh/.zshrc
@@ -65,8 +65,16 @@ function cwt() {
     return 1
   fi
 
+  local main_dir=$(pwd)
   echo "ブランチ: $branch"
   git wt "$branch" main --copyignored || return 1
+
+  # worktree の settings.local.json を main のものへのシンボリックリンクに置き換え
+  if [ -f "$main_dir/.claude/settings.local.json" ]; then
+    mkdir -p .claude
+    rm -f .claude/settings.local.json
+    ln -s "$main_dir/.claude/settings.local.json" .claude/settings.local.json
+  fi
 
   claude "$task"
 }


### PR DESCRIPTION
## Summary
- `cwt`でworktree作成後、`.claude/settings.local.json`をmainのファイルへのシンボリックリンクに置き換えるようにした
- worktree内でClaude Codeが`allow`した設定が、mainブランチにもリアルタイムで反映されるようになる

## 背景
`.claude/settings.local.json`は`.gitignore_global`でGit追跡対象外のため、worktreeで許可した設定がmainに反映されない問題があった。

## 変更内容
- worktree作成後にmainの`.claude/settings.local.json`が存在する場合、worktree側のファイルをシンボリックリンクに置き換える

## Test plan
- [ ] `cwt`でworktreeを作成し、`.claude/settings.local.json`がシンボリックリンクになっていることを確認
- [ ] worktree内でClaude Codeが`allow`を追加し、mainの`settings.local.json`にも反映されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)