### PR TITLE
feat: cwtのgit wtコマンドの引数を更新

### DIFF
--- a/packages/zsh/.zshrc
+++ b/packages/zsh/.zshrc
@@ -67,7 +67,7 @@ function cwt() {
 
   local main_dir=$(pwd)
   echo "ブランチ: $branch"
-  git wt "$branch" main --copyignored || return 1
+  git wt "$branch" develop --copy ".env*" || return 1
 
   # worktree の settings.local.json を main のものへのシンボリックリンクに置き換え
   if [ -f "$main_dir/.claude/settings.local.json" ]; then


### PR DESCRIPTION
## Summary
- cwtのベースブランチを`main`から`develop`に変更
- `--copyignored`オプションを`--copy ".env*"`に変更し、コピー対象を明示的に指定

🤖 Generated with [Claude Code](https://claude.com/claude-code)