### PR TITLE
feat: cwtのgit wtで--copyignoredを--copy ".env*"に変更

### DIFF
--- a/packages/zsh/.zshrc
+++ b/packages/zsh/.zshrc
@@ -67,7 +67,7 @@ function cwt() {
 
   local main_dir=$(pwd)
   echo "ブランチ: $branch"
-  git wt "$branch" main --copyignored || return 1
+  git wt "$branch" main --copy ".env*" || return 1
 
   # worktree の settings.local.json を main のものへのシンボリックリンクに置き換え
   if [ -f "$main_dir/.claude/settings.local.json" ]; then


### PR DESCRIPTION
## Summary
- `--copyignored`オプションを`--copy ".env*"`に変更し、コピー対象を.envファイルのみに明示的に限定

🤖 Generated with [Claude Code](https://claude.com/claude-code)