### PR TITLE
feat: mainブランチでのClaude Codeセッションにコード変更制約を追加

### DIFF
--- a/packages/zsh/.zshrc
+++ b/packages/zsh/.zshrc
@@ -49,6 +49,18 @@ eval "$(/opt/homebrew/bin/mise activate zsh)"
 # git-wt (git worktree helper)
 eval "$(git wt --init zsh)"
 
+# claude: mainブランチではコード変更を行わないセッションとして起動
+function claude() {
+  local branch=$(git branch --show-current 2>/dev/null)
+  if [ "$branch" = "main" ] || [ "$branch" = "master" ]; then
+    command claude --append-system-prompt \
+      "現在mainブランチにいます。このセッションではコードの変更やgit操作（checkout, commit, branch作成等）を行わないでください。issue起票、アーキテクチャ議論、調査、レビューなど、コード変更を伴わないタスクのみ対応してください。実装が必要な場合はissueを作成するか、ユーザーにcwtコマンドの使用を提案してください。" \
+      "$@"
+  else
+    command claude "$@"
+  fi
+}
+
 # cwt: claude worktree - タスクからブランチ名を決定しworktreeを作成して対話開始
 function cwt() {
   local task="$*"
@@ -58,7 +70,7 @@ function cwt() {
   fi
 
   echo "ブランチ名を決定中..."
-  local branch=$(claude -p "以下のタスクに適切なgitブランチ名を1つだけ出力して。命名規則: feature/xxx, fix/xxx, docs/xxx。英語ケバブケース。ブランチ名のみ出力。タスク: $task" | tr -d '`')
+  local branch=$(command claude -p "以下のタスクに適切なgitブランチ名を1つだけ出力して。命名規則: feature/xxx, fix/xxx, docs/xxx。英語ケバブケース。ブランチ名のみ出力。タスク: $task" | tr -d '`')
 
   if [ -z "$branch" ]; then
     echo "ブランチ名の決定に失敗しました"
@@ -79,5 +91,5 @@ function cwt() {
     ln -s "$main_dir/.claude/settings.local.json" .claude/settings.local.json
   fi
 
-  claude "$task"
+  command claude "$task"
 }


### PR DESCRIPTION
## Summary
- mainブランチで `claude`（または `cl`）を起動した際、`--append-system-prompt` でコード変更・git操作を禁止する指示を自動付与するシェル関数を追加
- `cwt` 内の `claude` 呼び出しを `command claude` に変更し、ラッパー関数を経由せず直接実行するように修正

## 変更内容
- `claude()` 関数を追加: mainブランチ検知時にread-onlyなセッション指示を付与
- `cwt()` 内の `claude` → `command claude` に変更: worktree内では制約なしで動作

## 動作
| コマンド | ブランチ | 挙動 |
|---------|---------|------|
| `cl` / `claude` | main | コード変更制約付きセッション |
| `cl` / `claude` | その他 | 通常セッション |
| `cwt <タスク>` | main→worktree | 通常セッション（command claude で直接実行） |

## Test plan
- [ ] mainブランチで `cl` を起動し、コード変更を依頼した際に拒否されることを確認
- [ ] worktreeブランチで `cl` を起動し、通常通りコード変更できることを確認
- [ ] `cwt` でworktree作成→Claude起動が正常に動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)