### PR TITLE
feat: delete-merged と wt-delete-merged を統合し squash merge 対応

### DIFF
--- a/packages/git/.gitconfig
+++ b/packages/git/.gitconfig
@@ -3,9 +3,6 @@ name = Hiroki SAKABE
 email = hiroki.sakabe@icloud.com
 
 [alias]
-delete-merged = "!f () { git checkout $1; git branch --merged|egrep -v '\\*|develop|main'|xargs git branch -d; };f"
-# マージ済みブランチの worktree を削除してブランチも削除
-wt-delete-merged = "!f() { base=${1:-$(git config default.branch || echo main)}; merged=$(git branch --merged \"$base\" --format='%(refname:short)' | grep -vE '^(main|develop)$'); if [ -z \"$merged\" ]; then echo \"No merged branches found.\"; return 0; fi; git worktree list --porcelain | awk '/^worktree /{wt=substr($0,10)} /^branch refs\\/heads\\//{b=substr($0,19); print wt \"|\" b}' | while IFS=\"|\" read -r wt_path branch_name; do if echo \"$merged\" | grep -qxF \"$branch_name\"; then echo \"Removing worktree: $wt_path (branch: $branch_name)\"; git worktree remove --force \"$wt_path\" && git branch -d \"$branch_name\"; fi; done; }; f"
 gg = "log --graph --pretty=oneline"
 # stash -> デフォルトブランチに移動 -> pull -> 元ブランチ削除 -> stash pop
 sdd = "!f() { CURRENT_BRANCH=$(git symbolic-ref --short HEAD); DEFAULT_BRANCH=$(git config default.branch); git stash; git checkout $DEFAULT_BRANCH; git pull; git branch -D $CURRENT_BRANCH; git stash pop; }; f"

--- a/packages/git/.local/bin/git-delete-merged
+++ b/packages/git/.local/bin/git-delete-merged
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+# git-delete-merged: GitHub PR のマージ状態を元にローカルブランチと worktree を削除
+# squash merge にも対応（gh api でPR状態を確認するため）
+set -euo pipefail
+
+if ! command -v gh &>/dev/null; then
+  echo "error: gh (GitHub CLI) is required"
+  exit 1
+fi
+
+current=$(git branch --show-current 2>/dev/null || echo "")
+branches=$(git branch --format='%(refname:short)' | grep -vE "^(main|master|develop|${current})$" || true)
+
+if [ -z "$branches" ]; then
+  echo "No branches to check."
+  exit 0
+fi
+
+deleted=0
+for branch in $branches; do
+  pr_number=$(gh pr list --head "$branch" --state merged --json number --jq '.[0].number' 2>/dev/null || true)
+
+  if [ -n "$pr_number" ]; then
+    # worktree があれば先に削除
+    wt_path=$(git worktree list --porcelain | awk -v branch="$branch" \
+      '/^worktree /{wt=substr($0,10)} /^branch refs\/heads\//{b=substr($0,19); if(b==branch) print wt}')
+
+    if [ -n "$wt_path" ]; then
+      echo "Removing worktree: $wt_path (branch: $branch)"
+      git worktree remove --force "$wt_path"
+    fi
+
+    echo "Deleting branch: $branch (PR #$pr_number)"
+    git branch -D "$branch"
+    deleted=$((deleted + 1))
+  fi
+done
+
+if [ "$deleted" -eq 0 ]; then
+  echo "No merged branches found."
+else
+  echo "Deleted $deleted merged branch(es)."
+fi

--- a/packages/zsh/.zshrc
+++ b/packages/zsh/.zshrc
@@ -1,4 +1,5 @@
 eval "$(/opt/homebrew/bin/brew shellenv)"
+export PATH="$HOME/.local/bin:$PATH"
 
 fpath+=("$(brew --prefix)/share/zsh/site-functions")
 


### PR DESCRIPTION
## Summary
- `delete-merged` と `wt-delete-merged` の2つの git alias を、1つのスクリプト `git-delete-merged` に統合
- `git branch --merged` の代わりに `gh pr list --state merged` で判定することで、squash merge されたブランチも正しく検出
- worktree があれば先に削除し、その後ブランチを削除する

## 変更内容
- `packages/git/.local/bin/git-delete-merged`: 新規スクリプト（git サブコマンド）
- `packages/git/.gitconfig`: 旧 `delete-merged` / `wt-delete-merged` alias を削除
- `packages/zsh/.zshrc`: `~/.local/bin` を PATH に追加

## 旧実装の問題点
`git branch --merged` はコミットの祖先関係で判定するため:
- ローカル main が古いと誤検知する
- squash merge されたブランチを検出できない

新実装は GitHub PR のマージ状態を直接確認するので、これらの問題が解消される。

## Test plan
- [ ] `make link` でシンボリックリンクを作成
- [ ] `git delete-merged` でマージ済みブランチ+worktree が削除されることを確認
- [ ] マージされていないブランチが削除されないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)