### PR TITLE
fix: WezTerm の新規タブ/ペインで cwd が引き継がれない問題を修正

### DIFF
--- a/packages/zsh/.zshrc
+++ b/packages/zsh/.zshrc
@@ -8,6 +8,12 @@ function set_win_title() {
 }
 precmd_functions+=(set_win_title)
 
+# OSC 7: ディレクトリ変更時にターミナルへ通知（WezTermの新しいタブ/ペインでcwdを引き継ぐため）
+function notify_cwd() {
+    printf '\e]7;file://%s%s\e\\' "${HOST}" "${PWD}"
+}
+chpwd_functions+=(notify_cwd)
+
 autoload -U compinit
 compinit
 
@@ -81,9 +87,6 @@ function cwt() {
   local main_dir=$(pwd)
   echo "ブランチ: $branch"
   git wt "$branch" main --copy ".env*" || return 1
-
-  # WezTermに現在のディレクトリを通知（新しいタブ/ペインで同じディレクトリを開くため）
-  printf '\e]7;file://%s%s\e\\' "${HOST}" "${PWD}"
 
   # worktree の settings.local.json を main のものへのシンボリックリンクに置き換え
   if [ -f "$main_dir/.claude/settings.local.json" ]; then


### PR DESCRIPTION
## Summary
- zsh の `chpwd` フックで OSC 7 エスケープシーケンスを送信し、ディレクトリ変更をターミナルに常時通知するようにした
- `cwt` 内の個別 OSC 7 送信は `chpwd` フックで代替されるため削除

## 原因
WezTerm は新しいタブ/ペインを開く際、OSC 7 で通知された最後のディレクトリを使用する。
従来は `cwt` 内でのみ OSC 7 を送信していたため、通常の `cd` 後に新しいタブを開くと別のディレクトリになることがあった。

## Test plan
- [ ] `cd` でディレクトリ移動後、Cmd+T で新しいタブを開き同じディレクトリになることを確認
- [ ] Cmd+| でペイン分割した際も同じディレクトリになることを確認
- [ ] `cwt` が引き続き正常動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)