### PR TITLE
fix: .gitconfig の autosquash typo を修正

### DIFF
--- a/packages/git/.gitconfig
+++ b/packages/git/.gitconfig
@@ -10,7 +10,7 @@ sdd = "!f() { CURRENT_BRANCH=$(git symbolic-ref --short HEAD); DEFAULT_BRANCH=$(
 [rebase]
 autostash = true
 abbreviateCommands = true
-autosqaush = true
+autosquash = true
 
 [pull]
 ff = only


### PR DESCRIPTION
## Summary
- `rebase.autosqaush` → `rebase.autosquash` の typo を修正
- この typo により `git rebase` 時の autosquash が有効になっていなかった

## Test plan
- [ ] `git config --get rebase.autosquash` で `true` が返ることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)