### PR TITLE
fix: install.sh のシェバング・exit・stow パッケージ一覧を修正

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,10 +1,10 @@
-#!/bin/sh
+#!/bin/bash
 
 kernelName="$(uname -s)"
 
-if [ $kernelName != 'Darwin' ]; then
+if [ "$kernelName" != 'Darwin' ]; then
   echo "Not support OS."
-  return 1
+  exit 1
 fi
 
 echo "\n-- install Homebrew and formulaes --"
@@ -16,9 +16,7 @@ brew bundle -v --cleanup
 echo "\n-- create symbolic links with stow --"
 mkdir -p ~/.config/yazi ~/.claude ~/.codex
 cd packages
-stow -v -t ~ zsh vim tmux wezterm git npm
-stow -v -t ~ starship yazi
-stow -v -t ~ claude codex
+stow -v -t ~ zsh vim tmux wezterm git npm starship yazi claude codex claude-skills
 cd ..
 
 echo "\n-- install GitAlias --"


### PR DESCRIPTION
## Summary
- `#!/bin/sh` → `#!/bin/bash` に変更（`&>` リダイレクト等の bash 構文を使用しているため）
- `return 1` → `exit 1` に変更（スクリプト内では `return` は使えない）
- 変数展開をクォート（`$kernelName` → `"$kernelName"`）
- stow パッケージ一覧を Makefile の `PACKAGES` と統一（`claude-skills` が漏れていた）

## Test plan
- [ ] `bash -n install.sh` で構文エラーがないことを確認
- [ ] Linux 環境で実行した場合にエラーメッセージが出て終了することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)