### PR TITLE
feat: WezTerm のカラースキームを Ubuntu に変更

### DIFF
--- a/packages/wezterm/.wezterm.lua
+++ b/packages/wezterm/.wezterm.lua
@@ -7,7 +7,7 @@ if wezterm.config_builder then
 end
 
 -- see https://leaysgur.github.io/wezterm-colorscheme/
-config.color_scheme = 'Twilight (light) (terminal.sexy)'
+config.color_scheme = 'Ubuntu'
 
 config.font = wezterm.font_with_fallback {
   { family = "Moralerspace Argon", assume_emoji_presentation = true }


### PR DESCRIPTION
## Summary
- WezTerm のカラースキームを `Twilight (light)` から `Ubuntu` に変更

## Test plan
- [ ] `make link` 後、WezTerm を再起動して Ubuntu カラースキームが適用されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)