### PR TITLE
feat: ターミナル全体を Ubuntu スタイルに統一

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -77,6 +77,7 @@ cask "monitorcontrol"
 cask "font-hackgen-nerd"
 cask "font-monaspace"
 cask "font-moralerspace"
+cask "font-ubuntu-mono-nerd-font"
 
 # --- Browsers ---
 cask "google-chrome"

--- a/packages/starship/.config/starship.toml
+++ b/packages/starship/.config/starship.toml
@@ -10,13 +10,17 @@ $line_break\
 $character"""
 
 
+[directory]
+style = "bold #e95420"
+
 [character]
-success_symbol = "❯"
-error_symbol = "❯"
-vimcmd_symbol = "❮"
+success_symbol = "[❯](#e95420)"
+error_symbol = "[❯](red)"
+vimcmd_symbol = "[❮](#e95420)"
 
 [git_branch]
 format = "[$branch]($style)"
+style = "bold #772953"
 
 [git_status]
 format = "[(*$conflicted$untracked$modified$staged$renamed$deleted) ($ahead_behind$stashed)]($style)"

--- a/packages/wezterm/.wezterm.lua
+++ b/packages/wezterm/.wezterm.lua
@@ -10,7 +10,39 @@ end
 config.color_scheme = 'Ubuntu'
 
 config.font = wezterm.font_with_fallback {
-  { family = "Moralerspace Argon", assume_emoji_presentation = true }
+  { family = "UbuntuMono Nerd Font", assume_emoji_presentation = true },
+  { family = "Moralerspace Argon", assume_emoji_presentation = true },
+}
+
+config.window_frame = {
+  font = wezterm.font { family = "UbuntuMono Nerd Font" },
+  active_titlebar_bg = '#300a24',
+  inactive_titlebar_bg = '#2c001e',
+}
+
+config.colors = {
+  tab_bar = {
+    active_tab = {
+      bg_color = '#300a24',
+      fg_color = '#ffffff',
+    },
+    inactive_tab = {
+      bg_color = '#2c001e',
+      fg_color = '#808080',
+    },
+    inactive_tab_hover = {
+      bg_color = '#5e2750',
+      fg_color = '#ffffff',
+    },
+    new_tab = {
+      bg_color = '#2c001e',
+      fg_color = '#808080',
+    },
+    new_tab_hover = {
+      bg_color = '#5e2750',
+      fg_color = '#ffffff',
+    },
+  },
 }
 
 config.font_size = 16.0


### PR DESCRIPTION
## Summary
- Brewfile に `font-ubuntu-mono-nerd-font` を追加
- WezTerm のフォントを UbuntuMono Nerd Font に変更（日本語は Moralerspace にフォールバック）
- WezTerm のタブバーを Ubuntu のダークパープル (`#300a24`) にカスタマイズ
- Starship プロンプトに Ubuntu カラーを適用
  - ディレクトリ: オレンジ (`#e95420`)
  - プロンプト記号: オレンジ (`#e95420`)
  - git ブランチ: パープル (`#772953`)

## Ubuntu カラーパレット
| 用途 | カラー | コード |
|------|--------|--------|
| タブバー背景 | ダークパープル | `#300a24` |
| タブホバー | ライトパープル | `#5e2750` |
| ディレクトリ/プロンプト | オレンジ | `#e95420` |
| git ブランチ | パープル | `#772953` |

## Test plan
- [ ] `brew install font-ubuntu-mono-nerd-font` でフォントをインストール
- [ ] `make link` 後、WezTerm を再起動して Ubuntu フォント・タブバー色を確認
- [ ] Starship プロンプトのカラーが Ubuntu 風になっていることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)