### PR TITLE
feat: worktrunk Claude Code plugin を導入

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: install update sync link unlink setup-mcp help
+.PHONY: install update sync link unlink setup-mcp setup-plugins help
 
 PACKAGES := zsh vim wezterm git npm starship yazi claude codex claude-skills worktrunk
 
@@ -23,3 +23,7 @@ unlink: ## Remove symlinks with stow
 
 setup-mcp: ## Setup MCP servers for Claude Code
 	-claude mcp add --scope user --transport stdio chrome-devtools -- npx chrome-devtools-mcp@latest
+
+setup-plugins: ## Setup Claude Code plugins
+	-claude plugin marketplace add max-sixty/worktrunk
+	-claude plugin install worktrunk@worktrunk

--- a/packages/claude/.claude/settings.json
+++ b/packages/claude/.claude/settings.json
@@ -60,8 +60,15 @@
       "Bash(pyftsubset:*)",
       "Skill(langfuse)"
     ],
-    "deny": ["Read(./.env)", "Read(./.env.*)"],
-    "ask": ["Bash(gh pr merge:*)", "Bash(git push:*)", "Bash(wt merge:*)"]
+    "deny": [
+      "Read(./.env)",
+      "Read(./.env.*)"
+    ],
+    "ask": [
+      "Bash(gh pr merge:*)",
+      "Bash(git push:*)",
+      "Bash(wt merge:*)"
+    ]
   },
   "hooks": {
     "Notification": [
@@ -84,5 +91,8 @@
         ]
       }
     ]
+  },
+  "enabledPlugins": {
+    "worktrunk@worktrunk": true
   }
 }


### PR DESCRIPTION
## Summary

- worktrunk Claude Code plugin をインストール（`wt list` でエージェント状態 🤖/💬 を表示）
- Makefile に `setup-plugins` ターゲットを追加（`make setup-plugins` で再セットアップ可能）
- `settings.json` に `enabledPlugins` 設定が自動追加

## Test plan

- [ ] `claude plugin list` で worktrunk@worktrunk が enabled であること
- [ ] `make setup-plugins` が正常に実行できること

🤖 Generated with [Claude Code](https://claude.com/claude-code)