### PR TITLE
feat: gh-dash を導入し設定を stow で管理

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 .PHONY: install update sync link unlink setup-mcp setup-plugins help
 
-PACKAGES := zsh vim wezterm git npm starship yazi claude codex claude-skills worktrunk
+PACKAGES := zsh vim wezterm git npm starship yazi claude codex claude-skills worktrunk gh-dash
 
 help: ## Show this help
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-15s\033[0m %s\n", $$1, $$2}'
@@ -15,7 +15,7 @@ sync: ## Sync current Homebrew packages to Brewfile
 	brew bundle dump --force --file=Brewfile
 
 link: ## Create symlinks with stow
-	@mkdir -p ~/.config/yazi ~/.claude ~/.codex ~/.config/worktrunk
+	@mkdir -p ~/.config/yazi ~/.claude ~/.codex ~/.config/worktrunk ~/.config/gh-dash
 	cd packages && stow -v -t ~ $(PACKAGES)
 
 unlink: ## Remove symlinks with stow

--- a/install.sh
+++ b/install.sh
@@ -14,10 +14,13 @@ fi
 brew bundle -v --cleanup
 
 echo "\n-- create symbolic links with stow --"
-mkdir -p ~/.config/yazi ~/.claude ~/.codex ~/.config/worktrunk
+mkdir -p ~/.config/yazi ~/.claude ~/.codex ~/.config/worktrunk ~/.config/gh-dash
 cd packages
-stow -v -t ~ zsh vim wezterm git npm starship yazi claude codex claude-skills worktrunk
+stow -v -t ~ zsh vim wezterm git npm starship yazi claude codex claude-skills worktrunk gh-dash
 cd ..
+
+echo "\n-- install gh extensions --"
+gh extension install dlvhdr/gh-dash || true
 
 echo "\n-- install GitAlias --"
 echo "Downloading GitAlias..."

--- a/packages/gh-dash/.config/gh-dash/config.yml
+++ b/packages/gh-dash/.config/gh-dash/config.yml
@@ -1,0 +1,91 @@
+prSections:
+    - title: My Pull Requests
+      filters: is:open author:@me
+    - title: Needs My Review
+      filters: is:open review-requested:@me
+    - title: Involved
+      filters: is:open involves:@me -author:@me
+issuesSections:
+    - title: My Issues
+      filters: is:open author:@me
+    - title: Assigned
+      filters: is:open assignee:@me
+    - title: Involved
+      filters: is:open involves:@me -author:@me
+notificationsSections:
+    - title: All
+      filters: ""
+    - title: Created
+      filters: reason:author
+    - title: Participating
+      filters: reason:participating
+    - title: Mentioned
+      filters: reason:mention
+    - title: Review Requested
+      filters: reason:review-requested
+    - title: Assigned
+      filters: reason:assign
+    - title: Subscribed
+      filters: reason:subscribed
+    - title: Team Mentioned
+      filters: reason:team-mention
+repo:
+    branchesRefetchIntervalSeconds: 30
+    prsRefetchIntervalSeconds: 60
+defaults:
+    preview:
+        open: true
+        width: 120
+    prsLimit: 20
+    prApproveComment: LGTM
+    issuesLimit: 20
+    notificationsLimit: 20
+    view: issues
+    layout:
+        prs:
+            updatedAt:
+                width: 5
+            createdAt:
+                width: 5
+            repo:
+                width: 20
+            author:
+                width: 15
+            authorIcon:
+                hidden: false
+            assignees:
+                width: 20
+                hidden: true
+            base:
+                width: 15
+                hidden: true
+            lines:
+                width: 15
+        issues:
+            updatedAt:
+                width: 5
+            createdAt:
+                width: 5
+            repo:
+                width: 15
+            creator:
+                width: 10
+            creatorIcon:
+                hidden: false
+            assignees:
+                width: 20
+                hidden: true
+    refetchIntervalMinutes: 30
+keybindings: {}
+repoPaths: {}
+theme:
+    ui:
+        sectionsShowCount: true
+        table:
+            showSeparator: true
+            compact: false
+pager:
+    diff: ""
+confirmQuit: false
+showAuthorIcons: true
+smartFilteringAtLaunch: true


### PR DESCRIPTION
## Summary

- gh-dash（GitHub TUI ダッシュボード）を導入
- `packages/gh-dash` として stow パッケージで設定を管理
- デフォルトビューを issues に設定、プレビュー幅を 120 に設定
- install.sh に `gh extension install dlvhdr/gh-dash` を追加

## Test plan

- [ ] `gh dash` で起動し、Issues ビューがデフォルトで表示されること
- [ ] `s` キーで PRs ビューに切り替えできること
- [ ] プレビューペインが十分な幅で表示されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)