### PR TITLE
fix: git delete-merged がメインワークツリーを削除しようとする問題を修正

### DIFF
--- a/packages/git/.local/bin/git-delete-merged
+++ b/packages/git/.local/bin/git-delete-merged
@@ -9,6 +9,7 @@ if ! command -v gh &>/dev/null; then
 fi
 
 current=$(git branch --show-current 2>/dev/null || echo "")
+main_wt=$(git worktree list --porcelain | sed -n '1s/^worktree //p')
 branches=$(git branch --format='%(refname:short)' | grep -vE "^(main|master|develop|${current})$" || true)
 
 if [ -z "$branches" ]; then
@@ -25,7 +26,7 @@ for branch in $branches; do
     wt_path=$(git worktree list --porcelain | awk -v branch="$branch" \
       '/^worktree /{wt=substr($0,10)} /^branch refs\/heads\//{b=substr($0,19); if(b==branch) print wt}')
 
-    if [ -n "$wt_path" ]; then
+    if [ -n "$wt_path" ] && [ "$wt_path" != "$main_wt" ]; then
       echo "Removing worktree: $wt_path (branch: $branch)"
       git worktree remove --force "$wt_path"
     fi


### PR DESCRIPTION
## Summary
- `git delete-merged` でメインワークツリーにマージ済みブランチがチェックアウトされている場合、`git worktree remove` が `fatal: is a main working tree` で失敗する問題を修正
- メインワークツリーのパスを事前に取得し、ワークツリー削除対象から除外するようにした

## Test plan
- [ ] メインワークツリーでマージ済みブランチがチェックアウトされた状態で `git delete-merged` を実行し、エラーが出ないことを確認
- [ ] 通常のワークツリー（サブワークツリー）のマージ済みブランチは引き続き正常に削除されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)