### PR TITLE
fix: git delete-merged がメインワークツリーのブランチを削除できない問題を修正

### DIFF
--- a/packages/git/.local/bin/git-delete-merged
+++ b/packages/git/.local/bin/git-delete-merged
@@ -29,6 +29,9 @@ for branch in $branches; do
     if [ -n "$wt_path" ] && [ "$wt_path" != "$main_wt" ]; then
       echo "Removing worktree: $wt_path (branch: $branch)"
       git worktree remove --force "$wt_path"
+    elif [ -n "$wt_path" ] && [ "$wt_path" = "$main_wt" ]; then
+      echo "Switching main worktree from $branch to main"
+      git -C "$main_wt" checkout main
     fi
 
     echo "Deleting branch: $branch (PR #$pr_number)"


### PR DESCRIPTION
## Summary
- `git delete-merged` でメインワークツリーにマージ済みブランチがチェックアウトされている場合、`git branch -D` が `error: cannot delete branch used by worktree` で失敗する問題を修正
- ブランチ削除前にメインワークツリーを `main` ブランチに自動で切り替えるようにした
- #125 の追加修正

## Test plan
- [ ] メインワークツリーでマージ済みブランチがチェックアウトされた状態で `git delete-merged` を実行し、自動で main に切り替わりブランチ削除が成功することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)