### PR TITLE
fix: git delete-merged がメインワークツリーのブランチを削除できない問題を修正

### DIFF
--- a/packages/git/.local/bin/git-delete-merged
+++ b/packages/git/.local/bin/git-delete-merged
@@ -30,8 +30,8 @@ for branch in $branches; do
       echo "Removing worktree: $wt_path (branch: $branch)"
       git worktree remove --force "$wt_path"
     elif [ -n "$wt_path" ] && [ "$wt_path" = "$main_wt" ]; then
-      echo "Switching main worktree from $branch to main"
-      git -C "$main_wt" checkout main
+      echo "Detaching main worktree from $branch"
+      git -C "$main_wt" checkout --detach
     fi
 
     echo "Deleting branch: $branch (PR #$pr_number)"


### PR DESCRIPTION
## Summary
- `git delete-merged` でメインワークツリーにマージ済みブランチがチェックアウトされている場合、`checkout main` が失敗する問題を修正
- `main` ブランチが他のワークツリーで使用中だと `checkout main` ができないため、`checkout --detach` で HEAD をデタッチしてブランチを解放するようにした
- #125, #126 の追加修正

## Test plan
- [ ] メインワークツリーでマージ済みブランチがチェックアウトされ、かつ `main` ブランチが別のワークツリーで使用中の状態で `git delete-merged` を実行し、正常に削除されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)