### PR TITLE
fix: git delete-merged のデフォルトブランチを動的取得に変更

### DIFF
--- a/packages/git/.local/bin/git-delete-merged
+++ b/packages/git/.local/bin/git-delete-merged
@@ -8,9 +8,10 @@ if ! command -v gh &>/dev/null; then
   exit 1
 fi
 
+default_branch=$(gh repo view --json defaultBranchRef --jq '.defaultBranchRef.name' 2>/dev/null || echo "main")
 current=$(git branch --show-current 2>/dev/null || echo "")
 main_wt=$(git worktree list --porcelain | sed -n '1s/^worktree //p')
-branches=$(git branch --format='%(refname:short)' | grep -vE "^(main|master|develop|${current})$" || true)
+branches=$(git branch --format='%(refname:short)' | grep -vE "^(${default_branch}|${current})$" || true)
 
 if [ -z "$branches" ]; then
   echo "No branches to check."


### PR DESCRIPTION
## 概要

`git delete-merged` でデフォルトブランチをハードコード（`main|master|develop`）から `gh repo view` による動的取得に変更。

- `gh repo view --json defaultBranchRef` でリポジトリのデフォルトブランチ名を取得
- 取得失敗時は `main` にフォールバック
- ハードコードされた除外リストを動的な値に置き換え

## テストプラン

- [ ] デフォルトブランチが `main` のリポジトリで `git delete-merged` が正常動作すること
- [ ] デフォルトブランチが `main` 以外のリポジトリで正しく除外されること
- [ ] `gh` コマンドがエラーになった場合に `main` にフォールバックすること

🤖 Generated with [Claude Code](https://claude.com/claude-code)