### PR TITLE
feat: setup-plugins に Anthropic 公式 skill-creator を追加

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,3 +27,5 @@ setup-mcp: ## Setup MCP servers for Claude Code
 setup-plugins: ## Setup Claude Code plugins
 	-claude plugin marketplace add max-sixty/worktrunk
 	-claude plugin install worktrunk@worktrunk
+	-claude plugin marketplace add anthropics/skills
+	-claude plugin install example-skills@anthropic-agent-skills


### PR DESCRIPTION
## Summary

- `make setup-plugins` に Anthropic 公式マーケットプレイス（`anthropics/skills`）からの `example-skills` プラグインインストールを追加
- `skill-creator` を含む複数のスキルが利用可能になる

## Test plan

- [ ] `make setup-plugins` を実行してプラグインがインストールされることを確認
- [ ] Claude Code で `/skill-creator` が認識されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)