### PR TITLE
fix: codex-review スキルのレビュー指示を改善

### DIFF
--- a/packages/claude-skills/.claude/skills/codex-review/SKILL.md
+++ b/packages/claude-skills/.claude/skills/codex-review/SKILL.md
@@ -21,9 +21,11 @@ description: 実装完了後、PR作成前に Codex CLI へコードレビュー
 git diff main...HEAD --stat
 git diff main...HEAD
 
-# 未コミットの変更がある場合
+# 未コミットの変更がある場合（unstaged + staged）
 git diff --stat
 git diff
+git diff --cached --stat
+git diff --cached
 ```
 
 2. 差分のファイル数と行数を確認し、レビュー方法を決定する。
@@ -56,15 +58,17 @@ Output format (respond in Japanese):
 4. 分割レビュー: 差分が大きい場合はファイル単位で分割してレビューする。
 
 ```bash
-# 変更ファイル一覧を取得
+# 変更ファイル一覧を取得（コミット済み + unstaged + staged の和集合）
 git diff main...HEAD --name-only
+git diff --name-only
+git diff --cached --name-only
 
 # ファイルごとに個別レビューを実行
 codex exec "Review the changes to <file-path> on the current branch compared to main.
 
 First, read the repository's AGENTS.md (if it exists) to understand project conventions.
 
-Evaluate from: Correctness, Readability, Consistency, Security, Performance.
+Evaluate from: Correctness, Readability, Consistency, Security, Performance, Tests.
 
 Output (respond in Japanese):
 - Each finding with severity (critical / warning / info), file path, line number, description, fix suggestion


### PR DESCRIPTION
## Summary

- codex-review スキルのレビュー指示を全面的に見直し、精度と網羅性を向上させた

## 変更内容

### 差分取得の修正
- `git diff main` → `git diff main...HEAD`（コミット済み変更を正確に取得）
- `git diff --cached` を追加（ステージ済み変更の漏れを防止）

### レビューコンテキストの強化
- Codex に AGENTS.md を参照させ、プロジェクト規約に沿ったレビューを実施するよう指示を追加

### レビュー観点の見直し
- `Bugs` → `Correctness` にリネーム
- `Consistency`（既存コードとの一貫性）観点を新規追加
- `Tests` に条件付き表現を追加（テストのないプロジェクトに対応）
- 一括・分割レビューで観点を統一

### 大きな差分への対処
- 500行超の差分に対するファイル単位の分割レビューフローを追加
- 分割レビューのファイル列挙で unstaged/staged の変更も含める

### その他
- 日本語での出力指示を追加
- タイムアウト時の分割再試行を失敗時対応に追加

## Test plan

- [x] SKILL.md の構文が正しいことを確認
- [x] Codex レビューを実行し、指摘事項を反映済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)