### PR TITLE
feat: add Prettier CI

### DIFF
--- a/.github/workflows/prettier.yml
+++ b/.github/workflows/prettier.yml
@@ -1,0 +1,15 @@
+name: Prettier
+
+on:
+  pull_request:
+    branches: [main]
+
+jobs:
+  prettier:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+      - run: npx prettier@3 --check .

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,11 @@
+packages/zsh/
+packages/vim/
+packages/wezterm/
+packages/git/
+packages/npm/
+Brewfile
+Brewfile.lock.json
+Makefile
+install.sh
+*.toml
+.wt/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,7 @@
 # Repository Guidelines
 
 ## Project Structure & Module Organization
+
 This repository manages dotfiles and CLI tool settings with GNU Stow.
 
 - `packages/`: one directory per tool (`zsh`, `vim`, `wezterm`, `git`, `codex`, etc.).
@@ -10,6 +11,7 @@ This repository manages dotfiles and CLI tool settings with GNU Stow.
 - `Brewfile` / `Brewfile.lock.json`: Homebrew package definitions and lock data.
 
 ## Build, Test, and Development Commands
+
 Use `make` targets as the standard workflow:
 
 - `make help`: list available tasks.
@@ -22,14 +24,16 @@ Use `make` targets as the standard workflow:
 Example: `make link` after adding a new file under `packages/zsh/`.
 
 ## Coding Style & Naming Conventions
+
 - Keep directory names tool-oriented and lowercase (for example, `packages/starship`).
 - Preserve target paths exactly as they should appear in `$HOME` (for example, `.config/gh-dash/config.yml`).
 - Prefer minimal, focused changes per package.
 - For shell snippets, use POSIX-compatible style unless the target tool requires `zsh`-specific syntax.
 
-No dedicated formatter/linter is configured at repository root; validate changes with relevant tool commands and `make` targets.
+Prettier is configured as the formatter. Run `npx prettier@3 --check .` to verify formatting. See `.prettierignore` for excluded files.
 
 ## Testing Guidelines
+
 There is no centralized automated test suite in this repository.
 
 - Verify symlink behavior with `make link` and `make unlink`.
@@ -37,6 +41,7 @@ There is no centralized automated test suite in this repository.
 - For tool-specific configs, run the tool’s own check command when available (for example, `git config --list`).
 
 ## Commit & Pull Request Guidelines
+
 - Follow Conventional Commit-like prefixes seen in history: `feat:`, `fix:`, `chore:`.
 - Keep commit scope small and message specific (example: `fix: adjust yazi preview keymap`).
 - Open PRs with:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,6 +29,12 @@ make unlink
 
 # Claude Code の MCP サーバーをセットアップ
 make setup-mcp
+
+# フォーマットチェック（CI と同じ）
+npx prettier@3 --check .
+
+# フォーマット適用
+npx prettier@3 --write .
 ```
 
 ## Architecture
@@ -56,6 +62,7 @@ Makefile           # タスクランナー
 `packages/` 配下の各ディレクトリは、ホームディレクトリ（`~`）へのシンボリックリンクとして展開される。例えば `packages/zsh/.zshrc` は `~/.zshrc` にリンクされる。
 
 新しいツールの設定を追加する場合：
+
 1. `packages/<tool>/` ディレクトリを作成
 2. ホームディレクトリからの相対パスで設定ファイルを配置
 3. `Makefile` の `PACKAGES` 変数にツール名を追加

--- a/packages/claude-skills/.claude/skills/codex-delegate/SKILL.md
+++ b/packages/claude-skills/.claude/skills/codex-delegate/SKILL.md
@@ -22,24 +22,29 @@ description: 実装・修正・テスト・PR作成タスクを Codex CLI へ委
 
 ```md
 # Task
+
 - 目的:
 - 背景:
 
 # Scope
+
 - In:
 - Out:
 
 # Constraints
+
 - 変更禁止:
 - 互換性要件:
 - 実行必須コマンド:
 
 # Acceptance Criteria
+
 1.
 2.
 3.
 
 # Target Files
+
 - path:
 ```
 

--- a/packages/claude/.claude/CLAUDE.md
+++ b/packages/claude/.claude/CLAUDE.md
@@ -28,6 +28,7 @@
 ブラウザ操作には agent-browser CLI を Bash ツール経由で使用する。
 
 基本ワークフロー:
+
 1. `agent-browser open <url>` — ページを開く
 2. `agent-browser snapshot -i` — インタラクティブ要素の ref を取得
 3. `agent-browser click @<ref>` / `agent-browser fill @<ref> "値"` — 要素を操作
@@ -35,6 +36,7 @@
 5. `agent-browser close` — ブラウザを閉じる
 
 主要コマンド:
+
 - ナビゲーション: open, back, forward, reload
 - 要素操作: click, fill, type, press, hover, select, check, scroll
 - 情報取得: get text, get html, get value, get title, get url

--- a/packages/claude/.claude/settings.json
+++ b/packages/claude/.claude/settings.json
@@ -63,15 +63,8 @@
       "Skill(codex-delegate)",
       "Skill(codex-review)"
     ],
-    "deny": [
-      "Read(./.env)",
-      "Read(./.env.*)"
-    ],
-    "ask": [
-      "Bash(gh pr merge:*)",
-      "Bash(git push:*)",
-      "Bash(wt merge:*)"
-    ]
+    "deny": ["Read(./.env)", "Read(./.env.*)"],
+    "ask": ["Bash(gh pr merge:*)", "Bash(git push:*)", "Bash(wt merge:*)"]
   },
   "hooks": {
     "Notification": [

--- a/packages/gh-dash/.config/gh-dash/config.yml
+++ b/packages/gh-dash/.config/gh-dash/config.yml
@@ -1,91 +1,91 @@
 prSections:
-    - title: My Pull Requests
-      filters: is:open author:@me
-    - title: Needs My Review
-      filters: is:open review-requested:@me
-    - title: Involved
-      filters: is:open involves:@me -author:@me
+  - title: My Pull Requests
+    filters: is:open author:@me
+  - title: Needs My Review
+    filters: is:open review-requested:@me
+  - title: Involved
+    filters: is:open involves:@me -author:@me
 issuesSections:
-    - title: My Issues
-      filters: is:open author:@me
-    - title: Assigned
-      filters: is:open assignee:@me
-    - title: Involved
-      filters: is:open involves:@me -author:@me
+  - title: My Issues
+    filters: is:open author:@me
+  - title: Assigned
+    filters: is:open assignee:@me
+  - title: Involved
+    filters: is:open involves:@me -author:@me
 notificationsSections:
-    - title: All
-      filters: ""
-    - title: Created
-      filters: reason:author
-    - title: Participating
-      filters: reason:participating
-    - title: Mentioned
-      filters: reason:mention
-    - title: Review Requested
-      filters: reason:review-requested
-    - title: Assigned
-      filters: reason:assign
-    - title: Subscribed
-      filters: reason:subscribed
-    - title: Team Mentioned
-      filters: reason:team-mention
+  - title: All
+    filters: ""
+  - title: Created
+    filters: reason:author
+  - title: Participating
+    filters: reason:participating
+  - title: Mentioned
+    filters: reason:mention
+  - title: Review Requested
+    filters: reason:review-requested
+  - title: Assigned
+    filters: reason:assign
+  - title: Subscribed
+    filters: reason:subscribed
+  - title: Team Mentioned
+    filters: reason:team-mention
 repo:
-    branchesRefetchIntervalSeconds: 30
-    prsRefetchIntervalSeconds: 60
+  branchesRefetchIntervalSeconds: 30
+  prsRefetchIntervalSeconds: 60
 defaults:
-    preview:
-        open: true
-        width: 120
-    prsLimit: 20
-    prApproveComment: LGTM
-    issuesLimit: 20
-    notificationsLimit: 20
-    view: issues
-    layout:
-        prs:
-            updatedAt:
-                width: 5
-            createdAt:
-                width: 5
-            repo:
-                width: 20
-            author:
-                width: 15
-            authorIcon:
-                hidden: false
-            assignees:
-                width: 20
-                hidden: true
-            base:
-                width: 15
-                hidden: true
-            lines:
-                width: 15
-        issues:
-            updatedAt:
-                width: 5
-            createdAt:
-                width: 5
-            repo:
-                width: 15
-            creator:
-                width: 10
-            creatorIcon:
-                hidden: false
-            assignees:
-                width: 20
-                hidden: true
-    refetchIntervalMinutes: 30
+  preview:
+    open: true
+    width: 120
+  prsLimit: 20
+  prApproveComment: LGTM
+  issuesLimit: 20
+  notificationsLimit: 20
+  view: issues
+  layout:
+    prs:
+      updatedAt:
+        width: 5
+      createdAt:
+        width: 5
+      repo:
+        width: 20
+      author:
+        width: 15
+      authorIcon:
+        hidden: false
+      assignees:
+        width: 20
+        hidden: true
+      base:
+        width: 15
+        hidden: true
+      lines:
+        width: 15
+    issues:
+      updatedAt:
+        width: 5
+      createdAt:
+        width: 5
+      repo:
+        width: 15
+      creator:
+        width: 10
+      creatorIcon:
+        hidden: false
+      assignees:
+        width: 20
+        hidden: true
+  refetchIntervalMinutes: 30
 keybindings: {}
 repoPaths: {}
 theme:
-    ui:
-        sectionsShowCount: true
-        table:
-            showSeparator: true
-            compact: false
+  ui:
+    sectionsShowCount: true
+    table:
+      showSeparator: true
+      compact: false
 pager:
-    diff: ""
+  diff: ""
 confirmQuit: false
 showAuthorIcons: true
 smartFilteringAtLaunch: true


### PR DESCRIPTION
## 概要

- PR の main ブランチへのマージ時に Prettier によるフォーマットチェックを CI で実行する GitHub Actions ワークフローを追加
- `npx prettier@3 --check .` で package.json 不要の最小構成
- 既存の Markdown, YAML, JSON ファイルに Prettier デフォルト設定でフォーマットを適用

## 変更内容

- `.github/workflows/prettier.yml`: PR 時に `npx prettier@3 --check .` を実行するワークフロー
- `.prettierignore`: シェル, Lua, Vim, Git 設定, TOML 等の非対象ファイルを除外
- `CLAUDE.md`: フォーマットコマンドを Commands セクションに追記
- `AGENTS.md`: formatter 設定の記述を更新
- 既存ファイル: Prettier デフォルト設定でフォーマット適用（空行追加、YAML インデント修正等）

## テスト計画

- [x] `npx prettier@3 --check .` が成功すること
- [ ] CI が正常に実行されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)