### PR TITLE
fix: cwt 関数でブランチ名に改行が含まれる問題を修正

### DIFF
--- a/packages/zsh/.zshrc
+++ b/packages/zsh/.zshrc
@@ -81,7 +81,7 @@ function cwt() {
   fi
 
   echo "ブランチ名を決定中..."
-  local branch=$(command claude -p "以下のタスクに適切なgitブランチ名を1つだけ出力して。命名規則: feature/xxx, fix/xxx, docs/xxx。英語ケバブケース。ブランチ名のみ出力。タスク: $task" | tr -d '`')
+  local branch=$(command claude -p "以下のタスクに適切なgitブランチ名を1つだけ出力して。命名規則: feature/xxx, fix/xxx, docs/xxx。英語ケバブケース。ブランチ名のみ出力。タスク: $task" | tr -d '`' | xargs)
 
   if [ -z "$branch" ]; then
     echo "ブランチ名の決定に失敗しました"


### PR DESCRIPTION
## Summary
- `cwt` 関数で Claude の出力からブランチ名を取得する際、改行文字が残りブランチ名が無効になる問題を修正
- `| xargs` を追加して改行や余分な空白を除去するようにした

## Test plan
- [x] `cwt` 関数でタスク説明を渡し、有効なブランチ名が生成されることを確認
- [x] Prettier フォーマットチェック通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)