### PR TITLE
feat: worktrunk の post-create で .env ファイルのみシンボリックリンクする

### DIFF
--- a/packages/worktrunk/.config/worktrunk/config.toml
+++ b/packages/worktrunk/.config/worktrunk/config.toml
@@ -7,12 +7,11 @@ command = "MAX_THINKING_TOKENS=0 claude -p --model=haiku --tools='' --disable-sl
 [post-create]
 symlink-env = """
 main_dir="{{ primary_worktree_path }}"
-for f in .env .env.local; do
-  if [ -f "$main_dir/$f" ]; then
-    ln -sf "$main_dir/$f" "$f"
-  else
-    rm -f "$f"
-  fi
+find "$main_dir" -maxdepth 5 -name '.env' -o -name '.env.local' | while read -r src; do
+  rel="${src#$main_dir/}"
+  dir="$(dirname "$rel")"
+  [ "$dir" != "." ] && mkdir -p "$dir"
+  ln -sf "$src" "$rel"
 done
 """
 claude-settings = """


### PR DESCRIPTION
## Summary

- worktrunk の `post-create` フックで、全 gitignored ファイルのコピー (`wt step copy-ignored`) を廃止
- 代わりに `.env` と `.env.local` のみをメインワークツリーからシンボリックリンクする方式に変更
- サブディレクトリの `.env` ファイルも再帰的に対象とする

## Test plan

- [ ] worktree を新規作成し、メインワークツリーの `.env` / `.env.local` がシンボリックリンクされることを確認
- [ ] サブディレクトリに `.env` がある場合もリンクされることを確認
- [ ] メインワークツリーに `.env` が存在しない場合、エラーなく完了することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)