### PR TITLE
feat: Asana MCP サーバーを追加

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,6 +23,7 @@ unlink: ## Remove symlinks with stow
 
 setup-mcp: ## Setup MCP servers for Claude Code
 	-claude mcp add --scope user --transport stdio chrome-devtools -- npx chrome-devtools-mcp@latest
+	-claude mcp add --scope user --transport http asana https://mcp.asana.com/mcp
 
 setup-plugins: ## Setup Claude Code plugins
 	-claude plugin marketplace add max-sixty/worktrunk


### PR DESCRIPTION
## Summary
- Makefile の `setup-mcp` ターゲットに Asana 公式 MCP サーバー (`https://mcp.asana.com/mcp`) を追加
- HTTP トランスポートを使用するリモート MCP サーバーで、OAuth 認証に対応
- ローカルの npm パッケージではなく、Asana がホストする公式エンドポイントを利用

## Test plan
- [ ] `make setup-mcp` を実行し、エラーなく完了することを確認
- [ ] `claude mcp get asana` で Asana MCP サーバーが登録されていることを確認
- [ ] Claude Code から Asana のタスク操作ができることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)