### PR TITLE
fix: close キーワードの誤使用を防ぐため CLAUDE.md の指示を明確化

### DIFF
--- a/packages/claude/.claude/CLAUDE.md
+++ b/packages/claude/.claude/CLAUDE.md
@@ -15,7 +15,7 @@
   - warning はユーザーに確認してから対応を決める
 - 作業完了後はコミットして PR を作成する
 - PR の description は日本語で記載する
-- PR の close <issue>は先頭に記載する
+- ユーザーから明示的に issue 番号を指定された場合のみ、PR description の先頭に `close #<issue番号>` を記載する。issue 番号が指定されていない場合は記載しない。Issue の作成・コメントには close キーワードを使わない
 
 ### CI/CD
 


### PR DESCRIPTION
## Summary
- issue 番号が指定されていない場合にも `close #XXX` が生成される問題に対応
- ユーザーから明示的に issue 番号が指定された場合のみ、PR description の先頭に `close #<issue番号>` を記載するよう条件を明確化
- Issue の作成・コメントでは close キーワードを使わないよう明記

## Test plan
- [ ] 新しい会話で issue 番号を指定せずに PR 作成を依頼し、`close #XXX` が含まれないことを確認
- [ ] issue 番号を指定して PR 作成を依頼し、`close #<番号>` が先頭に記載されることを確認
- [ ] Issue 作成時に close キーワードが使われないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)