### PR TITLE
feat: mise の idiomatic_version_file_enable_tools に node を追加

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 .PHONY: install update sync link unlink setup-mcp setup-plugins help
 
-PACKAGES := zsh vim wezterm git npm starship yazi claude codex claude-skills worktrunk gh-dash gram
+PACKAGES := zsh vim wezterm git npm starship yazi claude codex claude-skills worktrunk gh-dash gram mise
 
 help: ## Show this help
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-15s\033[0m %s\n", $$1, $$2}'
@@ -15,7 +15,7 @@ sync: ## Sync current Homebrew packages to Brewfile
 	brew bundle dump --force --file=Brewfile
 
 link: ## Create symlinks with stow
-	@mkdir -p ~/.config/yazi ~/.claude ~/.codex ~/.config/worktrunk ~/.config/gh-dash ~/.config/gram
+	@mkdir -p ~/.config/yazi ~/.claude ~/.codex ~/.config/worktrunk ~/.config/gh-dash ~/.config/gram ~/.config/mise
 	cd packages && stow -v -t ~ $(PACKAGES)
 
 unlink: ## Remove symlinks with stow

--- a/packages/mise/.config/mise/config.toml
+++ b/packages/mise/.config/mise/config.toml
@@ -1,0 +1,6 @@
+[tools]
+node = "latest"
+python = "latest"
+
+[settings]
+idiomatic_version_file_enable_tools = ["python", "node"]


### PR DESCRIPTION
## Summary
- mise の設定ファイル (`packages/mise/.config/mise/config.toml`) を Stow パッケージとして新規追加
- `idiomatic_version_file_enable_tools` に `node` を追加し、`.node-version` ファイルによるバージョン指定を有効化
- Makefile に mise パッケージの登録と `~/.config/mise` ディレクトリの事前作成を追加

## Test plan
- [ ] `make link` でシンボリックリンクが正しく作成されること
- [ ] `mise settings` で `idiomatic_version_file_enable_tools` に `node` が含まれていること
- [ ] `.node-version` ファイルがあるディレクトリで `mise` が正しく Node バージョンを切り替えること

🤖 Generated with [Claude Code](https://claude.com/claude-code)