### PR TITLE
feat: Claude Code の許可リストに Bash(echo:*) を追加

### DIFF
--- a/packages/claude/.claude/settings.json
+++ b/packages/claude/.claude/settings.json
@@ -61,7 +61,8 @@
       "Bash(pyftsubset:*)",
       "Skill(langfuse)",
       "Skill(codex-delegate)",
-      "Skill(codex-review)"
+      "Skill(codex-review)",
+      "Bash(echo:*)"
     ],
     "deny": ["Read(./.env)", "Read(./.env.*)"],
     "ask": ["Bash(gh pr merge:*)", "Bash(git push:*)", "Bash(wt merge:*)"]


### PR DESCRIPTION
## 概要

- Claude Code の `settings.json` の許可リスト（allow）に `Bash(echo:*)` を追加

## 背景

`&&` でチェインしたコマンド（例: `git diff ... && echo "---" && cat ...`）を実行する際、`echo` が許可リストに含まれていないため毎回承認を求められていた。`echo` を許可することでこの問題を解消する。

## テスト計画

- [ ] `&&` チェインで `echo` を含むコマンドが承認なしで実行されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)