### PR TITLE
feat: .zshrc の brew --prefix 呼び出しを削減

### DIFF
--- a/packages/zsh/.zshrc
+++ b/packages/zsh/.zshrc
@@ -1,7 +1,7 @@
 eval "$(/opt/homebrew/bin/brew shellenv)"
 export PATH="$HOME/.local/bin:$PATH"
 
-fpath+=("$(brew --prefix)/share/zsh/site-functions")
+fpath+=("/opt/homebrew/share/zsh/site-functions")
 
 function set_win_title() {
     echo -ne "\033]0; $(basename "$PWD") \007"
@@ -25,8 +25,8 @@ setopt share_history
 setopt hist_ignore_all_dups
 setopt auto_cd
 
-source $(brew --prefix)/share/zsh-autosuggestions/zsh-autosuggestions.zsh
-source $(brew --prefix)/share/zsh-syntax-highlighting/zsh-syntax-highlighting.zsh
+source /opt/homebrew/share/zsh-autosuggestions/zsh-autosuggestions.zsh
+source /opt/homebrew/share/zsh-syntax-highlighting/zsh-syntax-highlighting.zsh
 
 # alias
 alias cd..="cd .."


### PR DESCRIPTION
close #151

## 概要

`.zshrc` で `$(brew --prefix)` を3箇所呼び出していたのを `/opt/homebrew` に置換し、シェル起動速度を改善する。

## 変更内容

- `fpath+=("$(brew --prefix)/share/zsh/site-functions")` → `/opt/homebrew/share/zsh/site-functions`
- `source $(brew --prefix)/share/zsh-autosuggestions/...` → `/opt/homebrew/share/zsh-autosuggestions/...`
- `source $(brew --prefix)/share/zsh-syntax-highlighting/...` → `/opt/homebrew/share/zsh-syntax-highlighting/...`

L1 で既に `/opt/homebrew/bin/brew` をハードコードしているため、統一する形で置換。

## Test plan

- [ ] 新しいシェルセッションを開き、zsh の補完が動作すること
- [ ] zsh-autosuggestions が有効であること
- [ ] zsh-syntax-highlighting が有効であること

🤖 Generated with [Claude Code](https://claude.com/claude-code)