### PR TITLE
install.sh の stow パッケージリストを Makefile に一元化

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -14,10 +14,7 @@ fi
 brew bundle -v --cleanup
 
 echo "\n-- create symbolic links with stow --"
-mkdir -p ~/.config/yazi ~/.claude ~/.codex ~/.config/worktrunk ~/.config/gh-dash
-cd packages
-stow -v -t ~ zsh vim wezterm git npm starship yazi claude codex claude-skills worktrunk gh-dash
-cd ..
+make link
 
 echo "\n-- install gh extensions --"
 gh extension install dlvhdr/gh-dash || true


### PR DESCRIPTION
close #149

## Summary
- `install.sh` で直接 `stow` コマンドを実行していた部分を `make link` の呼び出しに置き換え
- これにより stow のパッケージリストが `Makefile` の `PACKAGES` 変数で一元管理されるようになり、新しいパッケージ追加時に `Makefile` だけ変更すれば済むようになる

## Test plan
- [ ] `make install` を実行し、シンボリックリンクが正しく作成されることを確認
- [ ] `make link` / `make unlink` が正常に動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)