### PR TITLE
fix: install.sh の echo を printf に置換

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -7,29 +7,29 @@ if [ "$kernelName" != 'Darwin' ]; then
   exit 1
 fi
 
-echo "\n-- install Homebrew and formulaes --"
+printf '\n-- install Homebrew and formulaes --\n'
 if ! command -v brew &> /dev/null; then
   curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install.sh | /bin/bash
 fi
 brew bundle -v --cleanup
 
-echo "\n-- create symbolic links with stow --"
+printf '\n-- create symbolic links with stow --\n'
 make link
 
-echo "\n-- install gh extensions --"
+printf '\n-- install gh extensions --\n'
 gh extension install dlvhdr/gh-dash || true
 
-echo "\n-- install GitAlias --"
+printf '\n-- install GitAlias --\n'
 echo "Downloading GitAlias..."
 mkdir -p ~/.git-extensions
 curl -fsSL https://raw.githubusercontent.com/GitAlias/gitalias/main/gitalias.txt -o ~/.git-extensions/gitalias.txt
 
 # Add GitAlias include to .gitconfig if it's not already there
 if ! grep -q "\[include\]" ~/.gitconfig || ! grep -q "path = ~/.git-extensions/gitalias.txt" ~/.gitconfig; then
-  echo "\n# GitAlias configuration\n[include]\n    path = ~/.git-extensions/gitalias.txt" >> ~/.gitconfig
+  printf '\n# GitAlias configuration\n[include]\n    path = ~/.git-extensions/gitalias.txt\n' >> ~/.gitconfig
   echo "GitAlias configured successfully!"
 else
   echo "GitAlias already configured."
 fi
 
-echo "\n-- done! --"
+printf '\n-- done! --\n'


### PR DESCRIPTION
close #153

## 概要

`install.sh` の `echo "\n..."` を `printf` に置換し、改行が正しく出力されるように修正。

## 変更内容

- セクション見出しの `echo "\n-- ... --"` を `printf '\n-- ... --\n'` に置換（L10, L16, L19, L22, L35）
- `.gitconfig` への GitAlias 設定追記も同様に `printf` に置換（L29）

## 背景

bash の `echo` はデフォルトでエスケープシーケンスを解釈しないため、`\n` がリテラル文字列として出力されていた。`printf` は POSIX 互換でエスケープシーケンスを確実に解釈する。

## テスト

- `npx prettier@3 --check .` — pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)