### PR TITLE
feat: Claude Code の voice と language 設定を追加

### DIFF
--- a/packages/claude/.claude/settings.json
+++ b/packages/claude/.claude/settings.json
@@ -1,4 +1,6 @@
 {
+  "voiceEnabled": true,
+  "language": "ja",
   "permissions": {
     "allow": [
       "Bash(find:*)",


### PR DESCRIPTION
## 概要

Claude Code の settings.json に以下の設定を追加しました。

- `voiceEnabled: true` — 音声モード（ホールドトゥトーク）を有効化
- `language: "ja"` — 応答言語と音声ディクテーションの言語を日本語に設定

## テスト計画

- [ ] `npx prettier@3 --check .` でフォーマットチェックが通ること
- [ ] Stow でシンボリックリンク展開後、Claude Code で voice と language 設定が反映されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)