### PR TITLE
fix: Brewfile から廃止済みの homebrew/cask-fonts tap を削除

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -1,6 +1,5 @@
 # --- Tap repositories ---
 tap "homebrew/bundle"
-tap "homebrew/cask-fonts"
 tap "charmbracelet/tap"
 tap "azure/functions"
 tap "timwehrle/asana"


### PR DESCRIPTION
close #162

## 概要

Homebrew 4.3.0（2024年5月）で `homebrew/cask-fonts` は廃止され、すべてのフォントが `homebrew/cask` に統合されました。Brewfile から不要な `tap "homebrew/cask-fonts"` を削除します。

## 変更内容

- `Brewfile` から `tap "homebrew/cask-fonts"` を削除

## 備考

- フォントの cask エントリ（`font-hackgen-nerd`, `font-monaspace`, `font-moralerspace`）は `homebrew/cask` 経由で引き続きインストール可能なため変更不要
- 参考: https://brew.sh/2024/05/14/homebrew-4.3.0/

🤖 Generated with [Claude Code](https://claude.com/claude-code)