### PR TITLE
feat: issue 起票フォーマット統一の issue-create Skill を追加

### DIFF
--- a/packages/claude-skills/.claude/skills/issue-create/SKILL.md
+++ b/packages/claude-skills/.claude/skills/issue-create/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: issue-create
-description: GitHub issue を統一フォーマットで起票する。ユーザーが「issue を立てて」「issue 化して」などを依頼したとき、または作業中に課題を issue として残したいときに使用する。dotfiles 以外のリポジトリでも利用する。
+description: GitHub issue を統一フォーマットで起票する。ユーザーが「issue を立てて」「issue 化して」などを依頼したとき、または作業中に課題を issue として残したいときに使用する。
 ---
 
 # Issue Create Skill


### PR DESCRIPTION
close #169

## 概要

Claude Code 経由で GitHub issue を起票する際のフォーマットを統一するため、グローバル配置の `issue-create` Skill を新設する。

## 変更内容

- `packages/claude-skills/.claude/skills/issue-create/SKILL.md` を新規追加
- 種別概念は持たず、共通セクション（概要 / 背景 / 受け入れ条件 / スコープ外 / 参考）と必要時の追加セクション（実装方針 / 再現手順 / 調査メモ）の組み合わせで表現
- 本文先頭に `Status: Ready` / `Status: Draft` を必須化し、Claude Code が着手前に確認する旨を明記
- 親子 issue は GitHub sub-issue 機能で紐づけ、子 issue 本文には親リンクと「実装前に親 issue を読むこと」の注意を必須化
- `gh issue create` は `--body-file -` + heredoc 形式でタイトルの記号混入にも安全な例を記載

## レビュー

Codex によるクロスレビューを実施。critical 0 件、warning 2 件のうち 1 件（コマンド安全性）を取り込み済み。

## Test plan

- [x] `npx prettier@3 --check .` 相当のフォーマットチェックが通ること