### PR TITLE
fix: Homebrew インストール URL を HEAD ブランチに更新

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -9,7 +9,7 @@ fi
 
 printf '\n-- install Homebrew and formulaes --\n'
 if ! command -v brew &> /dev/null; then
-  curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install.sh | /bin/bash
+  curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh | /bin/bash
 fi
 brew bundle -v --cleanup
 


### PR DESCRIPTION
close #152

## 概要

`install.sh` の Homebrew インストール URL が古い `master` ブランチを参照していたため、現在の公式ドキュメントに合わせて `HEAD` に更新する。

## 変更内容

- `install.sh`: `Homebrew/install/master/install.sh` → `Homebrew/install/HEAD/install.sh`

## 検証

- `npx prettier@3 --check install.sh` 通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)