### PR TITLE
refactor: gh copilot extension から standalone copilot CLI へ移行

### DIFF
--- a/packages/claude-skills/.claude/skills/codex-delegate/SKILL.md
+++ b/packages/claude-skills/.claude/skills/codex-delegate/SKILL.md
@@ -48,10 +48,10 @@ description: 実装・修正・テスト・PR作成タスクを Codex CLI へ委
 - path:
 ```
 
-2. 整理した内容を使い、`gh copilot` で実装を委譲する。
+2. 整理した内容を使い、`copilot` CLI で実装を委譲する。
 
 ```bash
-gh copilot -- -p "Implement the task in the current repository. Follow repository instructions. Run required lint/format/test checks. Create a branch, commit changes, open a PR, and report changed files, verification commands, commit SHA, and PR URL." --model gpt-5.3-codex --allow-all --silent --no-ask-user
+copilot -p "Implement the task in the current repository. Follow repository instructions. Run required lint/format/test checks. Create a branch, commit changes, open a PR, and report changed files, verification commands, commit SHA, and PR URL." --allow-all --no-ask-user -s
 ```
 
 3. Codex の結果を確認し、次の形式で要約して返す。
@@ -64,5 +64,5 @@ gh copilot -- -p "Implement the task in the current repository. Follow repositor
 ## 失敗時の対応
 
 - 仕様が不足している場合は実装を開始せず、不足項目を列挙してユーザーへ確認する。
-- `gh copilot` コマンドが見つからない場合は `gh extension list` で確認し、未導入であることとインストール手順（`gh extension install github/gh-copilot`）を案内する。
+- `copilot` コマンドが見つからない場合は `command -v copilot` で確認し、未導入であれば `brew install --cask copilot-cli` でのインストールを案内する。初回利用時は `copilot login` で GitHub Copilot サブスクリプションでの認証が必要。
 - CI が失敗した場合は失敗ログ要約と修正方針を提示する。

--- a/packages/claude-skills/.claude/skills/codex-review/SKILL.md
+++ b/packages/claude-skills/.claude/skills/codex-review/SKILL.md
@@ -32,10 +32,10 @@ git diff --cached
    - **差分が 500 行以下**: 一括レビュー（ステップ 3 へ）
    - **差分が 500 行超**: ファイル単位で分割レビュー（ステップ 4 へ）
 
-3. 一括レビュー: 差分の概要を整理し、`gh copilot` でレビューを委譲する。
+3. 一括レビュー: 差分の概要を整理し、`copilot` CLI でレビューを委譲する。
 
 ```bash
-gh copilot -- -p "Review the changes on the current branch compared to main.
+copilot -p "Review the changes on the current branch compared to main.
 
 First, read the repository's AGENTS.md (if it exists) to understand project conventions and coding standards.
 
@@ -52,7 +52,7 @@ Output format (respond in Japanese):
 - List each finding with severity: critical / warning / info
 - For each finding, include: file path, line number or range, description, and a concrete fix suggestion
 - If no issues found, state that the code looks good
-- End with a summary table: total findings by severity" --model gpt-5.3-codex --allow-all --silent --no-ask-user
+- End with a summary table: total findings by severity" --allow-all --no-ask-user -s
 ```
 
 4. 分割レビュー: 差分が大きい場合はファイル単位で分割してレビューする。
@@ -64,7 +64,7 @@ git diff --name-only
 git diff --cached --name-only
 
 # ファイルごとに個別レビューを実行
-gh copilot -- -p "Review the changes to <file-path> on the current branch compared to main.
+copilot -p "Review the changes to <file-path> on the current branch compared to main.
 
 First, read the repository's AGENTS.md (if it exists) to understand project conventions.
 
@@ -72,7 +72,7 @@ Evaluate from: Correctness, Readability, Consistency, Security, Performance, Tes
 
 Output (respond in Japanese):
 - Each finding with severity (critical / warning / info), file path, line number, description, fix suggestion
-- If no issues, state the file looks good" --model gpt-5.3-codex --allow-all --silent --no-ask-user
+- If no issues, state the file looks good" --allow-all --no-ask-user -s
 ```
 
 最後に全ファイルのレビュー結果を集約してサマリーを作成する。
@@ -84,6 +84,6 @@ Output (respond in Japanese):
 
 ## 失敗時の対応
 
-- `gh copilot` コマンドが見つからない場合は `gh extension list` で確認し、未導入であることとインストール手順（`gh extension install github/gh-copilot`）を案内する。
+- `copilot` コマンドが見つからない場合は `command -v copilot` で確認し、未導入であれば `brew install --cask copilot-cli` でのインストールを案内する。初回利用時は `copilot login` で GitHub Copilot サブスクリプションでの認証が必要。
 - 差分がない場合はレビュー不要としてスキップする。
 - Copilot CLI がタイムアウトした場合は、差分を分割して再試行する。

--- a/packages/claude/.claude/settings.json
+++ b/packages/claude/.claude/settings.json
@@ -20,7 +20,7 @@
       "Bash(git:*)",
       "Bash(gh:*)",
       "Bash(npm:*)",
-      "Bash(gh copilot:*)",
+      "Bash(copilot:*)",
       "Bash(npx:*)",
       "WebFetch(domain:github.com)",
       "WebFetch(domain:raw.githubusercontent.com)",


### PR DESCRIPTION
close #176

## 概要

`codex-delegate` / `codex-review` Skill などで使用していた `gh copilot` extension 呼び出しを、後継の standalone `copilot` CLI へ置き換えた。

## 変更点

- `packages/claude-skills/.claude/skills/codex-delegate/SKILL.md`
  - `gh copilot -- -p ...` → `copilot -p ... --allow-all --no-ask-user -s`
  - 旧 `--model gpt-5.3-codex` は新 CLI に該当モデルがないため削除（デフォルトモデルを使用）
  - トラブルシュートを `brew install --cask copilot-cli` / `copilot login` 案内に更新
- `packages/claude-skills/.claude/skills/codex-review/SKILL.md`
  - 同様にコマンド 2 箇所とトラブルシュートを更新
- `packages/claude/.claude/settings.json`
  - permission を `Bash(gh copilot:*)` → `Bash(copilot:*)` に置き換え

`Brewfile` には既に `cask \"copilot-cli\"` が含まれているため、インストール経路の追加は不要。

## 動作確認

- `copilot --help` で `-p` / `--allow-all` / `--no-ask-user` / `-s` が利用可能であることを確認
- `npx prettier@3 --check .` がパス
- `codex-review` Skill 相当のレビューを新 `copilot` CLI 経由で実行し、入出力契約（差分の評価結果出力）が満たせることを確認

## スコープ外

- Skill 名（`codex-delegate` / `codex-review`）のリネーム
- 新 CLI の MCP 統合・カスタムエージェント等の活用

🤖 Generated with [Claude Code](https://claude.com/claude-code)