### PR TITLE
chore: wezterm の透過設定を削除

### DIFF
--- a/packages/wezterm/.wezterm.lua
+++ b/packages/wezterm/.wezterm.lua
@@ -77,23 +77,8 @@ config.keys = {
   },
 }
 config.window_close_confirmation = 'NeverPrompt'
-config.window_background_opacity = 0.5
-config.macos_window_background_blur = 20
 config.native_macos_fullscreen_mode = true
 config.initial_cols = 120
 config.initial_rows = 40
-
-wezterm.on('window-resized', function(window, pane)
-  local overrides = window:get_config_overrides() or {}
-  local dimensions = window:get_dimensions()
-
-  if dimensions.is_full_screen then
-    overrides.window_background_opacity = 1
-  else
-    overrides.window_background_opacity = 0.5
-  end
-
-  window:set_config_overrides(overrides)
-end)
 
 return config


### PR DESCRIPTION
## 概要

wezterm のウィンドウ背景透過関連設定を削除する。

## 変更内容

- `packages/wezterm/.wezterm.lua`
  - `window_background_opacity` を削除
  - `macos_window_background_blur` を削除
  - フルスクリーン時に opacity を切り替えていた `window-resized` イベントハンドラを削除

## 動作確認

- `npx prettier@3 --check .` 通過
- `make link` で反映確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)