### PR TITLE
feat: WezTerm のフォントサイズを 13.0 に変更

### DIFF
--- a/packages/wezterm/.wezterm.lua
+++ b/packages/wezterm/.wezterm.lua
@@ -47,7 +47,7 @@ config.colors = {
   },
 }
 
-config.font_size = 16.0
+config.font_size = 13.0
 config.scrollback_lines = 10000
 config.keys = {
   {


### PR DESCRIPTION
## 概要

WezTerm のフォントサイズを 16.0 から 13.0 に変更。

## 変更内容

- `packages/wezterm/.wezterm.lua` の `config.font_size` を `16.0` → `13.0` に変更

## 確認手順

- `make link` でシンボリックリンクを更新
- WezTerm を再起動してフォントサイズが 13.0 になっていることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)