### PR TITLE
feat: codex-review にドキュメント更新漏れチェックの観点を追加

### DIFF
--- a/packages/claude-skills/.claude/skills/codex-review/SKILL.md
+++ b/packages/claude-skills/.claude/skills/codex-review/SKILL.md
@@ -47,6 +47,7 @@ Then evaluate the diff from these perspectives:
 4. **Security**: Is there proper input validation? Are secrets or credentials exposed?
 5. **Performance**: Are there unnecessary computations or inefficient patterns?
 6. **Tests**: If the project has tests, is coverage adequate for the changes?
+7. **Documentation**: Are related docs (README, CLAUDE.md, AGENTS.md, inline comments, etc.) updated to reflect the changes? Flag missing or outdated documentation.
 
 Output format (respond in Japanese):
 - List each finding with severity: critical / warning / info
@@ -68,7 +69,7 @@ copilot --model gpt-5.3-codex -p "Review the changes to <file-path> on the curre
 
 First, read the repository's AGENTS.md (if it exists) to understand project conventions.
 
-Evaluate from: Correctness, Readability, Consistency, Security, Performance, Tests.
+Evaluate from: Correctness, Readability, Consistency, Security, Performance, Tests, Documentation.
 
 Output (respond in Japanese):
 - Each finding with severity (critical / warning / info), file path, line number, description, fix suggestion


### PR DESCRIPTION
## 概要

- codex-review スキルのレビュー観点に **Documentation**（ドキュメント更新漏れチェック）を追加
- 一括レビュー・分割レビューの両方のプロンプトに反映

## 変更内容

- `packages/claude-skills/.claude/skills/codex-review/SKILL.md`
  - 一括レビューのプロンプトに 7 番目の観点 `Documentation` を追加
  - 分割レビューの `Evaluate from:` リストに `Documentation` を追加

## 確認方法

- `npx prettier@3 --check .` でフォーマットチェック通過を確認済み
- codex-review スキルを実行し、レビュー観点に Documentation が含まれることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)