### PR TITLE
feat: .env の Read 権限を deny から ask に変更

### DIFF
--- a/packages/claude/.claude/settings.json
+++ b/packages/claude/.claude/settings.json
@@ -66,8 +66,14 @@
       "Skill(agent-browser)",
       "Bash(echo:*)"
     ],
-    "deny": ["Read(./.env)", "Read(./.env.*)"],
-    "ask": ["Bash(gh pr merge:*)", "Bash(git push:*)", "Bash(wt merge:*)"]
+    "deny": [],
+    "ask": [
+      "Bash(gh pr merge:*)",
+      "Bash(git push:*)",
+      "Bash(wt merge:*)",
+      "Read(./.env)",
+      "Read(./.env.*)"
+    ]
   },
   "hooks": {
     "PostToolUse": [


### PR DESCRIPTION
## Summary

- Claude Code の settings.json で `.env` / `.env.*` の Read 権限を `deny` から `ask` に変更
- 完全拒否ではなく都度確認にすることで、必要な場面で `.env` を参照可能にする

## 変更内容

- `permissions.deny` から `Read(./.env)`, `Read(./.env.*)` を削除
- `permissions.ask` に `Read(./.env)`, `Read(./.env.*)` を追加

## 検証手順

- `npx prettier@3 --check .` でフォーマット確認済み
- `make link` でシンボリックリンクが正しく作成されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)