### PR TITLE
chore: Brewfile から monitorcontrol を削除

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -76,7 +76,6 @@ cask "inkscape"
 cask "raspberry-pi-imager"
 cask "logi-options+"
 cask "deepl"
-cask "monitorcontrol"
 
 # --- Fonts ---
 cask "font-hackgen-nerd"


### PR DESCRIPTION
## 概要

- Brewfile から `cask "monitorcontrol"` を削除

## 確認手順

- `make update` で Brewfile の変更が正しく反映されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)