### PR TITLE
chore: container ツールを OrbStack + podman に整理

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -47,9 +47,7 @@ brew "pipx"
 brew "uv"
 
 # --- Container & VM ---
-brew "lima"
 brew "podman"
-cask "docker-desktop"
 cask "orbstack"
 
 # --- Cloud & IaC ---


### PR DESCRIPTION
## Summary

- Brewfile から `lima` と `docker-desktop` を削除
- container ツールを `orbstack` + `podman` の構成に整理
- 機能が重複するツールを削除し、軽量な構成に統一

## 変更内容

| 変更 | ツール | 理由 |
|------|--------|------|
| 削除 | `lima` | OrbStack が VM 管理を兼ねるため不要 |
| 削除 | `docker-desktop` | OrbStack が Docker 互換機能を提供するため不要 |
| 維持 | `podman` | rootless コンテナ実行用として継続利用 |
| 維持 | `orbstack` | Docker/Kubernetes 互換の軽量ランタイムとして利用 |

## Test plan

- [ ] `make update` で Brewfile の変更が正しく反映されること
- [ ] `orbstack` と `podman` が引き続き利用可能であること

🤖 Generated with [Claude Code](https://claude.com/claude-code)