### PR TITLE
feat: issue-create スキルに sub-issue 紐づけ手順を追加

### DIFF
--- a/packages/claude-skills/.claude/skills/issue-create/SKILL.md
+++ b/packages/claude-skills/.claude/skills/issue-create/SKILL.md
@@ -132,7 +132,28 @@ Status: Ready
    EOF
    ```
 
-5. 起票後、issue URL をユーザーに返す。親 issue がある場合は GitHub UI もしくは `gh api` で sub-issue として紐づける（手動でのリンク付けが必要な場合はその旨を案内）。
+5. 起票後、issue URL を保持する（まだユーザーに返さない）。
+6. **親 issue がある場合は、必ず `gh api` で sub-issue として紐づける。** この手順を省略してはならない。
+
+   ```bash
+   # gh issue create の出力 URL から子 issue 番号を抽出
+   CHILD_ISSUE_URL="<gh issue create が返した URL>"
+   CHILD_ISSUE_NUMBER="${CHILD_ISSUE_URL##*/}"
+   PARENT_ISSUE_NUMBER=<親 issue 番号>
+
+   # リポジトリ名を取得
+   REPO=$(gh repo view --json nameWithOwner --jq '.nameWithOwner')
+
+   # 子 issue の node ID を取得
+   CHILD_ID=$(gh issue view "$CHILD_ISSUE_NUMBER" --json id --jq '.id')
+
+   # 親 issue に sub-issue として追加
+   gh api "repos/${REPO}/issues/${PARENT_ISSUE_NUMBER}/sub_issues" \
+     -X POST \
+     -f sub_issue_id="$CHILD_ID"
+   ```
+
+7. 紐づけ完了を確認してから、issue URL をユーザーに返す。
 
 ## やらないこと
 


### PR DESCRIPTION
## Summary

- issue-create スキルで親 issue がある場合に、`gh api` で sub-issue として必ず紐づける具体的な手順を追加
- 曖昧だった「GitHub UI もしくは gh api で紐づける」という記述を、コマンド例付きの必須手順に変更
- 実行手順の順序を整理し、紐づけ完了後に URL を返す流れに統一

## 変更内容

- `packages/claude-skills/.claude/skills/issue-create/SKILL.md`
  - 手順 5〜7 を再構成: issue 作成 → sub-issue 紐づけ → URL 返却の順序に
  - `gh issue create` の出力 URL から issue 番号を抽出する方法を明記
  - `gh repo view` でリポジトリ名を動的に取得するコマンドを追加
  - sub-issue 紐づけの `gh api` コマンド例を具体的に記載
  - 「この手順を省略してはならない」と明記

## Test plan

- [ ] SKILL.md の Prettier フォーマットチェックが通ることを確認済み
- [ ] 実際に子 issue を起票する際に sub-issue 紐づけが実行されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)