### PR TITLE
fix: webfetch-history-append.sh のドメイン抽出を修正

### DIFF
--- a/packages/claude/.claude/scripts/webfetch-history-append.sh
+++ b/packages/claude/.claude/scripts/webfetch-history-append.sh
@@ -17,7 +17,7 @@ is_error=$(printf '%s' "$input" | jq -r '.tool_response.is_error // false')
 url=$(printf '%s' "$input" | jq -r '.tool_input.url // empty')
 [ -n "$url" ] || exit 0
 
-domain=$(printf '%s' "$url" | sed 's|https\?://||' | cut -d'/' -f1)
+domain=$(printf '%s' "$url" | sed -E 's|https?://||' | cut -d'/' -f1)
 [ -n "$domain" ] || exit 0
 
 ts=$(date -u +"%Y-%m-%dT%H:%M:%SZ")


### PR DESCRIPTION
## Summary

- macOS BSD sed で `\?` が拡張正規表現として認識されず、WebFetch 履歴のドメインが `https:` として記録されていた問題を修正
- `sed` に `-E` フラグを追加し、拡張正規表現モードで正しくドメインを抽出するように変更

## 原因

BSD sed（macOS デフォルト）では基本正規表現の `\?` が「0回または1回」として認識されない。そのため `sed 's|https\?://||'` がマッチせず、URL がそのまま残り、`cut -d'/' -f1` が `https:` を返していた。

## 検証

```bash
# 修正前（BSD sed）
echo "https://example.com/path" | sed 's|https\?://||' | cut -d'/' -f1
# → https:

# 修正後
echo "https://example.com/path" | sed -E 's|https?://||' | cut -d'/' -f1
# → example.com
```

## Test plan

- [ ] `make link` でシンボリックリンクを更新
- [ ] WebFetch を使用して `~/.claude/webfetch-history.jsonl` に正しいドメインが記録されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)