### PR TITLE
feat: Lightpanda 導入と agent-browser デフォルトエンジン変更

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -5,6 +5,7 @@ tap "azure/functions"
 tap "timwehrle/asana"
 tap "k1LoW/tap"
 tap "steipete/tap"
+tap "lightpanda-io/browser"
 
 # --- Shell & Environment ---
 brew "zsh"
@@ -80,6 +81,9 @@ cask "font-hackgen-nerd"
 cask "font-monaspace"
 cask "font-moralerspace"
 cask "font-jetbrains-mono-nerd-font"
+
+# --- Headless Browser ---
+brew "lightpanda"
 
 # --- Browsers ---
 cask "google-chrome"

--- a/packages/claude/.claude/CLAUDE.md
+++ b/packages/claude/.claude/CLAUDE.md
@@ -21,9 +21,15 @@
 - CI が失敗した場合は、ログを確認して修正する
 - CI が開始されない場合は、ブランチのコンフリクトが原因の可能性がある。コンフリクトを解消してから再度確認すること。
 
-### ブラウザ操作
+### ブラウザ操作（Lightpanda + agent-browser）
 
-ブラウザ操作は `agent-browser` Skill を使用する。詳細は `~/.claude/skills/agent-browser/SKILL.md` を参照。
+ブラウザ操作は `agent-browser` Skill を `--engine lightpanda` 付きで使用する。
+
+```bash
+agent-browser --engine lightpanda <command>
+```
+
+詳細は `~/.claude/skills/agent-browser/SKILL.md` を参照。
 
 ### 最新情報の参照
 


### PR DESCRIPTION
## Summary

- Brewfile に `lightpanda-io/browser` tap と `lightpanda` formula を追加
- CLAUDE.md のブラウザ操作セクションを更新し、`agent-browser --engine lightpanda` をデフォルトの使用方法として記載

## 変更内容

### Brewfile
- `tap "lightpanda-io/browser"` を追加
- `brew "lightpanda"` を `# --- Headless Browser ---` セクションとして追加

### packages/claude/.claude/CLAUDE.md
- 「ブラウザ操作」セクションを「ブラウザ操作（Lightpanda + agent-browser）」に変更
- `--engine lightpanda` フラグ付きの使用例を追加

## 確認手順

- [ ] `make update` で Lightpanda がインストールされること
- [ ] `agent-browser --engine lightpanda open example.com` で動作すること
- [ ] `make link` でシンボリックリンクが正しく作成されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)