### PR TITLE
fix: Brewfile の lightpanda formula 指定を tap 付きフルパスに修正

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -83,7 +83,7 @@ cask "font-moralerspace"
 cask "font-jetbrains-mono-nerd-font"
 
 # --- Headless Browser ---
-brew "lightpanda"
+brew "lightpanda-io/browser/lightpanda"
 
 # --- Browsers ---
 cask "google-chrome"


### PR DESCRIPTION
close #209

## 概要

Brewfile の `brew "lightpanda"` を `brew "lightpanda-io/browser/lightpanda"` に変更し、`brew bundle` 実行時に formula が見つからないエラーを修正。

## 変更内容

- `Brewfile`: lightpanda の formula 指定を tap 付きフルパス (`lightpanda-io/browser/lightpanda`) に修正

## 背景

tap `lightpanda-io/browser` は定義済みだが、formula 行で tap を明示していないため `homebrew/core` から探しに行き、`No available formula with the name "lightpanda"` エラーが発生していた。

## 確認手順

- `make update` が lightpanda のエラーなく完了すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)