### PR TITLE
feat: zsh-syntax-highlighting を fast-syntax-highlighting に置き換え

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -10,7 +10,7 @@ tap "lightpanda-io/browser"
 # --- Shell & Environment ---
 brew "zsh"
 brew "zsh-autosuggestions"
-brew "zsh-syntax-highlighting"
+brew "zsh-fast-syntax-highlighting"
 brew "starship"
 brew "direnv"
 brew "stow"

--- a/packages/zsh/.zshrc
+++ b/packages/zsh/.zshrc
@@ -26,7 +26,7 @@ setopt hist_ignore_all_dups
 setopt auto_cd
 
 source /opt/homebrew/share/zsh-autosuggestions/zsh-autosuggestions.zsh
-source /opt/homebrew/share/zsh-syntax-highlighting/zsh-syntax-highlighting.zsh
+source /opt/homebrew/opt/zsh-fast-syntax-highlighting/share/zsh-fast-syntax-highlighting/fast-syntax-highlighting.plugin.zsh
 
 # alias
 alias cd..="cd .."


### PR DESCRIPTION
close #212

## 概要

zsh-syntax-highlighting を zsh-fast-syntax-highlighting に乗り換え、シンタックスハイライトの品質とパフォーマンスを向上させる。

## 変更内容

- `Brewfile`: `zsh-syntax-highlighting` → `zsh-fast-syntax-highlighting` に変更
- `packages/zsh/.zshrc`: source パスを fast-syntax-highlighting の公式推奨パスに変更

## 検証手順

- `make link` でシンボリックリンクを作成
- 新しいターミナルを開き、コマンド入力時にシンタックスハイライトが機能することを確認
- `npx prettier@3 --check .` でフォーマットチェックが通ることを確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)