### PR TITLE
feat: WezTerm の GPU レンダリング・フォント描画設定を最適化

### DIFF
--- a/packages/wezterm/.wezterm.lua
+++ b/packages/wezterm/.wezterm.lua
@@ -47,6 +47,9 @@ config.colors = {
   },
 }
 
+config.front_end = 'WebGpu'
+config.freetype_load_flags = 'NO_HINTING'
+
 config.font_size = 13.0
 config.scrollback_lines = 10000
 config.keys = {


### PR DESCRIPTION
close #213

## 概要

WezTerm のレンダリングフロントエンドとフォント描画設定を明示的に指定し、描画品質とパフォーマンスを向上させる。

## 変更内容

- `config.front_end = 'WebGpu'` を追加 — macOS では Metal バックエンドを使用し、起動時のフロントエンド自動選択オーバーヘッドを省略
- `config.freetype_load_flags = 'NO_HINTING'` を追加 — Retina ディスプレイでのフォント描画をシャープに最適化

## 確認手順

1. `make link` でシンボリックリンクを更新
2. WezTerm を再起動し、描画が正常に動作することを確認
3. `npx prettier@3 --check .` でフォーマットチェックが通ることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)