### PR TITLE
feat: WezTerm に背景透過とブラー設定を追加

### DIFF
--- a/packages/wezterm/.wezterm.lua
+++ b/packages/wezterm/.wezterm.lua
@@ -94,6 +94,8 @@ wezterm.on('format-tab-title', function(tab)
   end
   return ' ' .. title .. ' '
 end)
+config.window_background_opacity = 0.9
+config.macos_window_background_blur = 20
 config.native_macos_fullscreen_mode = true
 config.initial_cols = 120
 config.initial_rows = 40


### PR DESCRIPTION
## Summary

- WezTerm に背景透過（opacity 0.9）とすりガラス風ブラー（blur 20）を追加
- craftzdog/dotfiles-public の Ghostty 設定を参考に、WezTerm 向けに適用

## 変更内容

- `packages/wezterm/.wezterm.lua` に以下を追加:
  - `config.window_background_opacity = 0.9`
  - `config.macos_window_background_blur = 20`

## 検証手順

- [ ] WezTerm 再起動（またはホットリロード）後、背景が透過していることを確認
- [ ] テキストの可読性に問題がないことを確認
- [ ] `npx prettier@3 --check .` が通ること

🤖 Generated with [Claude Code](https://claude.com/claude-code)