### PR TITLE
feat: WezTerm のフォントを Overpass Mono Nerd Font に変更

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -80,6 +80,7 @@ cask "font-hackgen-nerd"
 cask "font-monaspace"
 cask "font-moralerspace"
 cask "font-jetbrains-mono-nerd-font"
+cask "font-overpass-nerd-font"
 
 # --- Headless Browser ---
 brew "lightpanda-io/browser/lightpanda"

--- a/packages/wezterm/.wezterm.lua
+++ b/packages/wezterm/.wezterm.lua
@@ -11,13 +11,13 @@ end
 config.color_scheme = 'iceberg-dark'
 
 config.font = wezterm.font_with_fallback {
-  { family = "JetBrainsMono Nerd Font", assume_emoji_presentation = true },
+  { family = "OverpassM Nerd Font", assume_emoji_presentation = true },
   { family = "Moralerspace Argon", assume_emoji_presentation = true },
 }
 
 -- Iceberg dark palette
 config.window_frame = {
-  font = wezterm.font { family = "JetBrainsMono Nerd Font" },
+  font = wezterm.font { family = "OverpassM Nerd Font" },
   active_titlebar_bg = '#0f1117',
   inactive_titlebar_bg = '#161821',
 }


### PR DESCRIPTION
## Summary

- WezTerm のメインフォントを JetBrains Mono Nerd Font から Overpass Mono Nerd Font に変更
- Brewfile に `font-overpass-nerd-font` を追加
- タブバーのフォントも合わせて変更

## 背景

- Red Hat 製の Overpass Mono は Highway Gothic にインスパイアされた幅広でゆっ��りしたデザイン
- Iceberg Dark との組み合わ���で視認性が良く、気分転換として採用

## 変更内容

- `packages/wezterm/.wezterm.lua`: フォントファミリーを `OverpassM Nerd Font` に変更（本文 + タブバー）
- `Brewfile`: `font-overpass-nerd-font` を追加

## 検証手順

- [ ] `make update` で Overpass Nerd Font がインストールされる
- [ ] WezTerm 再起動後、フォントが Overpass Mono に変わっている
- [ ] タブバーのフォントも変更されている
- [ ] Nerd Font アイコン（Starship, yazi 等）が正常に表示される
- [ ] `npx prettier@3 --check .` が通ること

🤖 Generated with [Claude Code](https://claude.com/claude-code)