### PR TITLE
fix: WezTerm の assume_emoji_presentation 設定を削除

### DIFF
--- a/packages/wezterm/.wezterm.lua
+++ b/packages/wezterm/.wezterm.lua
@@ -11,8 +11,8 @@ end
 config.color_scheme = 'iceberg-dark'
 
 config.font = wezterm.font_with_fallback {
-  { family = "OverpassM Nerd Font", assume_emoji_presentation = true },
-  { family = "Moralerspace Argon", assume_emoji_presentation = true },
+  { family = "OverpassM Nerd Font" },
+  { family = "Moralerspace Argon" },
 }
 
 -- Iceberg dark palette


### PR DESCRIPTION
close #224

## 概要

WezTerm の `font_with_fallback` 設定から `assume_emoji_presentation = true` を削除し、OverpassM Nerd Font が通常テキストに正しく適用されるようにする。

## 変更内容

- `packages/wezterm/.wezterm.lua`: `font_with_fallback` 内の 2 つのフォントエントリから `assume_emoji_presentation = true` を削除

## 背景

`assume_emoji_presentation = true` が設定されていると、WezTerm のフォント選択の第 1 パスで通常テキスト（ASCII）に対してそのフォントがスキップされ、built-in の JetBrains Mono にフォールバックしていた。OverpassM Nerd Font は絵文字グリフを持たないため、この設定を削除しても絵文字表示には影響しない。

## 確認手順

1. `make link` でシンボリックリンクを更新
2. WezTerm を再起動
3. `wezterm ls-fonts --text "abc"` で OverpassM Nerd Font が使用されていることを確認
4. テキスト表示が Overpass フォントの字形になっていることを目視確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)