### PR TITLE
feat: Claude Code の Agent Teams 実験的機能を有効化

### DIFF
--- a/packages/claude/.claude/settings.json
+++ b/packages/claude/.claude/settings.json
@@ -1,6 +1,9 @@
 {
   "voiceEnabled": true,
   "language": "ja",
+  "env": {
+    "CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS": "1"
+  },
   "permissions": {
     "allow": [
       "Bash(find:*)",


### PR DESCRIPTION
## Summary

- Claude Code の `settings.json` に `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS` 環境変数を追加
- 複数の Claude Code インスタンスをチームとして協調動作させる実験的機能を有効化

## 変更内容

`packages/claude/.claude/settings.json` の `env` フィールドに `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS: "1"` を追加。

## 確認方法

- `make link` でシンボリックリンクを更新
- Claude Code セッションで `TeamCreate` などのチーム関連ツールが利用可能になることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)