### PR TITLE
fix: worktrunk の hook 設定セクション名を pre-start にリネーム

### DIFF
--- a/packages/worktrunk/.config/worktrunk/config.toml
+++ b/packages/worktrunk/.config/worktrunk/config.toml
@@ -4,7 +4,7 @@ squash = false
 [commit.generation]
 command = "MAX_THINKING_TOKENS=0 claude -p --model=haiku --tools='' --disable-slash-commands --setting-sources='' --system-prompt=''"
 
-[post-create]
+[pre-start]
 symlink-env = """
 main_dir="{{ primary_worktree_path }}"
 find "$main_dir" -maxdepth 5 -name '.env' -o -name '.env.local' | while read -r src; do


### PR DESCRIPTION
## Summary

- worktrunk (cwt) の `post-create` hook が `pre-start` にリネームされたことに追従し、`config.toml` のセクション名を修正

## 変更内容

- `packages/worktrunk/.config/worktrunk/config.toml` の `[post-create]` セクションを `[pre-start]` にリネーム

## 確認手順

- `make link` でシンボリックリンクを作成し、`~/.config/worktrunk/config.toml` が正しく反映されていることを確認
- `cwt create` で worktree 作成時にエラーが発生しないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)