### PR TITLE
feat: Claude Code statusLine にトークン量・5h rate limit・branch を表示

### DIFF
--- a/packages/claude/.claude/settings.json
+++ b/packages/claude/.claude/settings.json
@@ -126,5 +126,9 @@
         "repo": "anthropics/skills"
       }
     }
+  },
+  "statusLine": {
+    "type": "command",
+    "command": "~/.claude/statusline.sh"
   }
 }

--- a/packages/claude/.claude/statusline.sh
+++ b/packages/claude/.claude/statusline.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+# Claude Code statusLine: model, branch, tokens, 5h rate limit
+input=$(cat)
+DIR=$(echo "$input" | jq -r '.workspace.current_dir')
+BRANCH=$(git -C "$DIR" branch --show-current 2>/dev/null || echo "?")
+echo "$input" | jq -r --arg b "$BRANCH" '
+  "[\(.model.display_name)] (\($b)) " +
+  "\(.context_window.total_input_tokens // 0) IN / \(.context_window.total_output_tokens // 0) OUT (\(.context_window.used_percentage // 0)%) " +
+  "| 5h: \(.rate_limits.five_hour.used_percentage // 0)% (resets \(.rate_limits.five_hour.resets_at // 0 | if . > 0 then strflocaltime("%H:%M") else "?" end))"
+'


### PR DESCRIPTION
## 概要

Claude Code の status line をカスタマイズし、セッション中の状態を一目で把握できるようにする。

## 表示項目

```
[Opus 4.7 (1M context)] (main) 58292 IN / 115093 OUT (22%) | 5h: 17% (resets 17:10)
```

- モデル名 (`model.display_name`)
- 現在の git branch (`git -C "$DIR" branch --show-current`、worktree 配下でも正しく動作)
- 累計入出力トークン (`context_window.total_input_tokens` / `total_output_tokens`)
- context 使用率 (`context_window.used_percentage`)
- 5 時間ウィンドウ rate limit 残量とリセット時刻 (`rate_limits.five_hour.*`、初回 API response 後に populate される)

## 変更内容

- `packages/claude/.claude/statusline.sh` (新規) — Claude Code が stdin に流す JSON を読んで上記フォーマットに整形
- `packages/claude/.claude/settings.json` — `statusLine.command` に `~/.claude/statusline.sh` を指定

## ローカル検証

- `npx prettier@3 --check .` 通過
- 実際の Claude Code session の dump JSON で動作確認 (rate_limits 含む全フィールド対応)
- mock JSON で worktree 想定のシナリオも確認

## 影響パッケージパス

- `packages/claude/`

## スコープ外 (将来の拡張余地)

- `seven_day` rate limit の表示
- コスト (`cost.total_cost_usd`) や経過時間の表示
- 多行 status line 化 (1 行目に git 情報、2 行目に context 情報など)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
