### PR TITLE
chore: Claude Code を auto mode 既定に変更し関連設定を整理

### DIFF
--- a/packages/claude/.claude/settings.json
+++ b/packages/claude/.claude/settings.json
@@ -1,6 +1,4 @@
 {
-  "voiceEnabled": true,
-  "language": "ja",
   "env": {
     "CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS": "1"
   },
@@ -73,7 +71,8 @@
       "Bash(wt merge:*)",
       "Read(./.env)",
       "Read(./.env.*)"
-    ]
+    ],
+    "defaultMode": "auto"
   },
   "hooks": {
     "PostToolUse": [
@@ -130,5 +129,8 @@
   "statusLine": {
     "type": "command",
     "command": "~/.claude/statusline.sh"
-  }
+  },
+  "language": "ja",
+  "voiceEnabled": true,
+  "skipAutoPermissionPrompt": true
 }


### PR DESCRIPTION
## 概要

Claude Code の `~/.claude/settings.json` を更新し、auto mode を既定の動作モードにする。あわせて関連する設定キーを整理する。

## 変更内容

- `permissions.defaultMode` を `"auto"` に設定
  - 自動承認モードを既定にすることで、低リスク操作の都度プロンプトを抑制
- `skipAutoPermissionPrompt: true` を追加
  - auto mode 起動時の初回オプトインダイアログをスキップ済みフラグとして保持
- `voiceEnabled: true` / `language: "ja"` をファイル末尾に移動
  - 既存の単純な top-level スカラーキーを末尾にまとめる整理 (機能変更なし)

## ローカル検証

- `npx prettier@3 --check .` 通過

## 影響パッケージパス

- `packages/claude/`

## スコープ外

- 他の Claude Code 設定の見直し
- 個別 permission rule (allow/ask) の追加・削除

🤖 Generated with [Claude Code](https://claude.com/claude-code)
