### PR TITLE
feat: Claude Code フルスクリーンレンダリングを有効化

### DIFF
--- a/packages/claude/.claude/settings.json
+++ b/packages/claude/.claude/settings.json
@@ -132,5 +132,6 @@
   },
   "language": "ja",
   "voiceEnabled": true,
-  "skipAutoPermissionPrompt": true
+  "skipAutoPermissionPrompt": true,
+  "tui": "fullscreen"
 }


### PR DESCRIPTION
## Summary

- `packages/claude/.claude/settings.json` に `"tui": "fullscreen"` を追加し、Claude Code のフルスクリーンレンダリング（alt-screen レンダラー）を既定で有効化する。
- ちらつきのないレンダリング・長い会話でも一定のメモリ使用量・マウスサポートが得られる（[公式ドキュメント](https://code.claude.com/docs/ja/fullscreen)）。
- Claude Code v2.1.89 以降で動作。`/tui default` でいつでもクラシックレンダラーに戻せる。

## Test plan

- [x] `npx prettier@3 --check packages/claude/.claude/settings.json` が通ることを確認
- [ ] `make link` 後、新しい Claude Code セッションを起動してフルスクリーンモードで立ち上がること（入力ボックスが画面下部に固定される）を確認
- [ ] `/tui` 実行時に `fullscreen` がアクティブと表示されることを確認