### PR TITLE
docs: issuekit bundle README / LICENSE / .stow-local-ignore を追加

### DIFF
--- a/packages/claude-skills/.stow-local-ignore
+++ b/packages/claude-skills/.stow-local-ignore
@@ -1,0 +1,2 @@
+^/README\.md$
+^/LICENSE$

--- a/packages/claude-skills/LICENSE
+++ b/packages/claude-skills/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Hiroki SAKABE
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/claude-skills/README.md
+++ b/packages/claude-skills/README.md
@@ -1,0 +1,67 @@
+# issuekit
+
+A Claude Code skill bundle for **issue-driven development**, where each GitHub issue is the canonical "rich plan" for a unit of work — and code is the only artifact that gets version-controlled.
+
+> **Japanese-oriented plugin.** issuekit is designed for Japanese-speaking solo developers. Skill bodies, descriptions, and this README are written in English, but the skills read Japanese section headers (e.g. `## 受け入れ条件`) hardcoded into issue bodies. Issue contents themselves are expected to remain in Japanese. If you want to use issuekit with English-only issues, you will currently need to fork and adjust the hardcoded keywords.
+
+> **Status.** Casual OSS. No SLA, no response guarantees. Distributed as-is for users who share the underlying philosophy. PRs and issues are welcome but may be closed without action if they conflict with the maintainer's solo-dev workflow.
+
+## Philosophy
+
+Most "spec-driven" or "plan-driven" frameworks for AI coding agents store the spec **in the repository** as markdown files (`spec.md`, `plan.md`, etc.) checked in alongside the code. issuekit takes a different position:
+
+- **Specs / plans are volatile.** They describe a single unit of intent. Once the work is merged, the plan is dead — what survives is the code, the test, and (if anything) a one-line commit message.
+- **Versioning volatile artifacts in git is friction.** A merged plan rots in the repo, gets stale, and pollutes diffs and search.
+- **GitHub issues are already a versioned, queryable, time-bounded plan store.** They have state (`open`/`closed`), threading, references, and a natural lifecycle that matches the work itself.
+
+So issuekit treats the GitHub issue as **the rich plan** for the work, and the repository contains only the durable artifacts (code, tests, configs). When the issue is closed, the plan disappears from the active surface area — exactly as intended.
+
+This is opinionated. issuekit will not be a good fit if you want plans to live next to the code, or if your team's workflow expects spec markdown checked in.
+
+## Comparison with related frameworks
+
+issuekit shares one core idea with Spec Kit, cc-spex, and superpowers: **make the "what" an explicit contract that an AI agent can read, follow, and be checked against.** Where they differ is _where_ that contract lives, and how compliance is verified.
+
+| Framework                                          | Contract location                                           | Verification model                                                                                    | Fit                                                 |
+| -------------------------------------------------- | ----------------------------------------------------------- | ----------------------------------------------------------------------------------------------------- | --------------------------------------------------- |
+| [Spec Kit](https://github.com/github/spec-kit)     | Spec markdown checked into the repo                         | Agent re-reads the spec                                                                               | Teams that want specs versioned alongside code      |
+| [cc-spex](https://github.com/rhuss/cc-spex)        | Spec markdown checked into the repo                         | Agent re-reads the spec                                                                               | Solo / small team, lighter than Spec Kit            |
+| [superpowers](https://github.com/obra/superpowers) | Skill bundle of general-purpose engineering workflows       | Skill conventions + agent judgment                                                                    | Broad augmentation of Claude Code; not spec-centric |
+| **issuekit**                                       | GitHub issue body (`## 受け入れ条件`, `## スコープ外`, ...) | `acceptance-check` skill mechanically verifies each acceptance criterion as `✓ / ✗ / ?` before commit | Solo dev who already runs an issue-first workflow   |
+
+The differentiator that matters most to issuekit's design is the verification model. Detailed specs help agents stay on-rails, but **spec compliance is itself a problem**: the longer the spec, the more places the agent can drift. issuekit's response is structural rather than prescriptive — instead of writing more spec, write fewer but **mechanically verifiable** acceptance criteria, and have a dedicated skill (`acceptance-check`) check them before commit. The spec stays small; the verification stays honest.
+
+## Skills
+
+issuekit ships the following Claude Code skills under `packages/claude-skills/.claude/skills/`:
+
+| Skill              | Role                                                                                                                                                   |
+| ------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `issue-create`     | Open a new GitHub issue using issuekit's standard format (`Status: Ready` / `Status: Draft` header, intent, plan, acceptance criteria, out-of-scope).  |
+| `issue-refine`     | Re-shape an existing issue (title-only or partially formatted) into the standard format.                                                               |
+| `issue-pick`       | Read-only triage: from a set of open issues, suggest the next one to take on, with rationale.                                                          |
+| `issue-implement`  | Drive the full cycle from an issue number: status check → implementation → cross-review → acceptance check → commit → PR → CI.                         |
+| `acceptance-check` | Read-only verifier that extracts `## 受け入れ条件` from an issue body and reports each item as `✓ / ✗ / ?`. Called by `issue-implement` before commit. |
+| `codex-review`     | Delegate a second-opinion code review to the Codex CLI before opening a PR. Called by `issue-implement` after implementation.                          |
+
+`issue-implement` is the orchestrator; the other skills are either entry points (`issue-create`, `issue-refine`, `issue-pick`) or verifiers it calls (`acceptance-check`, `codex-review`).
+
+## Dependencies
+
+issuekit assumes the following tools are available on the host:
+
+- **[Claude Code](https://docs.claude.com/en/docs/claude-code)** — the agent runtime that loads the skills.
+- **[`gh` CLI](https://cli.github.com/)** — used for all GitHub interactions (issue read/write, PR creation, CI status).
+- **[Codex CLI](https://github.com/openai/codex)** — used by `codex-review` to obtain a cross-review from a different model. Install with `brew install --cask codex` (or the equivalent for your platform).
+
+`gh` must be authenticated against the repository you want to operate on. Codex CLI must be reachable on `PATH`; if it is not installed, `codex-review` will fail explicitly rather than silently skipping the review.
+
+## Install
+
+> **Placeholder.** Install instructions will be added once issuekit is packaged as a Claude Code plugin (tracked in #236).
+>
+> Until then, the only supported deployment path is the maintainer's personal dotfiles repository, where the skills are stowed as part of a larger setup. **Do not run this dotfiles repository's `make link` to install issuekit alone** — it would stow every package in the repo (`zsh`, `git`, `vim`, ...) into your home directory and overwrite unrelated config. If you want to try issuekit before the plugin manifest lands, the closest package-scoped equivalent is to `stow` only the `claude-skills` package against `~`, but this is unsupported and may break without notice.
+
+## License
+
+[MIT](./LICENSE).


### PR DESCRIPTION
close #237

## 目的

`packages/claude-skills/` を **issuekit** という bundle 名で配布できる状態に整える。issue-driven cycle skill bundle の入り口となる README、LICENSE (MIT)、Stow 除外設定を追加する。

## 影響パッケージ

- `packages/claude-skills/`
  - `README.md` (新規, 英語、Casual OSS / Japanese-oriented plugin 向け)
  - `LICENSE` (新規, MIT)
  - `.stow-local-ignore` (新規, `README.md` / `LICENSE` を `~` への stow 対象から除外)

## 変更内容

- `README.md`: 思想 / Spec Kit / cc-spex / superpowers との比較表 / 各 skill (`issue-create`, `issue-refine`, `issue-pick`, `issue-implement`, `acceptance-check`, `codex-review`) の役割 / 依存ツール (gh CLI / Codex CLI / Claude Code) / install プレースホルダ章 / "Japanese-oriented plugin" の明示。
- `LICENSE`: MIT、Copyright 2026 Hiroki SAKABE。
- `.stow-local-ignore`: `^/README\.md$` と `^/LICENSE$` を Stow から除外し、`make link` で `~/README.md` / `~/LICENSE` が作られないようにする。

## ローカル検証

- `stow -t <隔離 target> claude-skills` を dry-run + 実走で実行し、`.claude` のみリンクされ `README.md` / `LICENSE` がリンクされないことを確認。
- `npx prettier@3 --check .` がパス。
- Codex CLI による cross-review を実施し、warning 2 件を反映 (install 手順での `make link` 注意書き、`issue-create` の Status ヘッダ言及)。
- `acceptance-check` skill で issue #237 の受け入れ条件 11 件すべてが ✓ であることを確認。

## スコープ外

- install 手順の中身 (#236 の plugin 化完了後に追記予定)。
- 既存 skill 本文の英語化 (別 issue)。
- Anthropic marketplace 申請 / 別 repo 切り出し (将来検討)。
