### PR TITLE
chore: worktrunk plugin を撤去

### DIFF
--- a/packages/apm/apm.yml
+++ b/packages/apm/apm.yml
@@ -5,7 +5,6 @@ author: Hiroki SAKABE
 dependencies:
   apm:
     - ~/.localskills/issuekit
-    - max-sixty/worktrunk
     - anthropics/skills/skills/frontend-design
     - anthropics/skills/skills/skill-creator
   mcp: []


### PR DESCRIPTION
close #266

## 概要

worktrunk plugin (APM 経由で deploy されていた `max-sixty/worktrunk`) を撤去する。worktrunk CLI 本体 (`brew install worktrunk`) と Stow 配下の `packages/worktrunk/.config/worktrunk/config.toml` は継続使用する。

## 変更点

- `packages/apm/apm.yml` の `dependencies.apm` から `max-sixty/worktrunk` を削除

`packages/claude/.claude/settings.json` の plugin 設定 (`enabledPlugins."worktrunk@worktrunk"` / `extraKnownMarketplaces.worktrunk`) は PR #267 (commit 1b8aad1) で既に撤去済みのため、本 PR での変更はない。

## ローカル副作用 (リポジトリ外)

以下は git 管理外のため本 PR の diff には含まれないが、issue #266 の受け入れ条件として実施済み:

- `~/.claude/plugins/marketplaces/worktrunk/` を削除
- `~/.claude/plugins/cache/worktrunk/` を削除
- `~/.claude/plugins/installed_plugins.json` / `known_marketplaces.json` には既に worktrunk エントリなし (前回 PR の APM 移行で消えていた)

## 撤去**しない**もの

- worktrunk CLI 本体 (`brew install worktrunk`、Brewfile 管理)
- Stow 配下の `packages/worktrunk/.config/worktrunk/config.toml`

## 受け入れ条件チェック結果

- ✓ settings.json から worktrunk 関連 plugin 設定が撤去される (前回 PR で完了済み)
- ✓ APM dependency から worktrunk が削除される (本 PR)
- ✓ `~/.claude/plugins/` から worktrunk 関連エントリが撤去される
- ✓ worktrunk CLI 本体 (`wt --version` → `wt 0.45.2`) が引き続き動作する
- ✓ Stow 配下の `~/.config/worktrunk/config.toml` symlink が引き続き有効
- ? Claude Code 起動時に worktrunk 関連エラーが出ない (要再起動確認、設定上は問題なし)

## ローカル検証

```bash
npx prettier@3 --check .   # All matched files use Prettier code style!
grep -c worktrunk packages/apm/apm.yml          # 0
grep -c worktrunk packages/claude/.claude/settings.json   # 0
wt --version                                     # wt 0.45.2
test -e ~/.config/worktrunk/config.toml && echo OK   # OK
```

## 影響パッケージ

- `packages/apm/`