### PR TITLE
chore: stow を --no-folding に切り替え mkdir -p の事前作成を整理

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,13 +15,13 @@ sync: ## Sync current Homebrew packages to Brewfile
 	brew bundle dump --force --file=Brewfile
 
 link: ## Create symlinks with stow and deploy Claude Code skills via APM
-	@mkdir -p ~/.config/yazi ~/.claude ~/.codex ~/.config/worktrunk ~/.config/gh-dash ~/.config/gram ~/.config/mise ~/.config/bat/themes ~/.config/lazygit ~/.config/wtf ~/.localskills
-	cd packages && stow -v -t ~ $(PACKAGES)
+	@mkdir -p ~/.localskills
+	cd packages && stow -v --no-folding -t ~ $(PACKAGES)
 	ln -snf "$$(pwd)/packages/claude-skills" ~/.localskills/issuekit
 	$(MAKE) apm-install
 
 unlink: ## Remove symlinks with stow
-	cd packages && stow -v -D -t ~ $(PACKAGES)
+	cd packages && stow -v --no-folding -D -t ~ $(PACKAGES)
 	rm -f ~/.localskills/issuekit
 
 apm-install: ## Deploy Claude Code skills/plugins via APM (uses ~/apm.yml managed by stow)


### PR DESCRIPTION
close #154

## 目的

新規パッケージ追加時に `Makefile` の `mkdir -p` 追記漏れがあると stow が folding し、他ツールが同じディレクトリにファイルを作ったとき dotfiles リポジトリ本体に直接書き込まれる事故が起きうる。これを `stow --no-folding` の常用で恒久的に防ぐ。

## 変更内容

- `Makefile` の `link` / `unlink` target で `stow` 呼び出しに `--no-folding` を付与
- `--no-folding` で stow が中間ディレクトリを実体として自動作成するようになるため、`mkdir -p` の長いリストを削除
- stow 管理外の `~/.localskills`（`ln -snf` で `issuekit` シンボリックリンクを貼る先）は引き続き `mkdir -p` で確保

## 影響パッケージパス

- `Makefile`

## 注意

- 既存環境では `make unlink` → `make link` で再リンクすること。`--no-folding` 切替後、folding 状態の symlink は通常 `stow -D` で解除されるが、`packages/claude-skills/.claude/skills` のように既にパッケージ側から実体が消えている historical case では手動削除が必要

## ローカル検証

- `make help`: target 一覧が正しく表示されることを確認
- temp HOME を作成して `stow -v --no-folding -t <temp> <PACKAGES>` を実行 → 全 16 ディレクトリが実体、25 ファイルが個別 symlink として作成されることを確認
- 続けて `stow -v --no-folding -D -t <temp> <PACKAGES>` で全 symlink が削除されることを確認
- `npx prettier@3 --check .`: pass