### PR TITLE
chore: disable fullscreen TUI renderer

### DIFF
--- a/packages/claude/.claude/settings.json
+++ b/packages/claude/.claude/settings.json
@@ -140,5 +140,5 @@
   "language": "ja",
   "voiceEnabled": true,
   "skipAutoPermissionPrompt": true,
-  "tui": "fullscreen"
+  "tui": "default"
 }


### PR DESCRIPTION
## 概要

Claude Code の TUI レンダラーを fullscreen（alt-screen）モードから classic main-screen レンダラーに切り替える。

## 変更内容

- `packages/claude/.claude/settings.json` の `tui` を `"fullscreen"` → `"default"` に変更

## 背景

`tui: "fullscreen"` は flicker-free な alt-screen レンダラー（`CLAUDE_CODE_NO_FLICKER=1` 相当）。スクロールバックが仮想化されるが、ターミナルの素のスクロールバッファとの相互作用や、セッション後のターミナル履歴に履歴が残らない等の不便さがあるため、classic レンダラーに戻す。

## 動作確認

- [x] `npx prettier@3 --check packages/claude/.claude/settings.json`
- [ ] Claude Code 再起動後にフルスクリーン化されないことを確認