### PR TITLE
fix(worktrunk): pre-start を array of tables 形式に移行

### DIFF
--- a/packages/worktrunk/.config/worktrunk/config.toml
+++ b/packages/worktrunk/.config/worktrunk/config.toml
@@ -4,7 +4,7 @@ squash = false
 [commit.generation]
 command = "MAX_THINKING_TOKENS=0 claude -p --model=haiku --tools='' --disable-slash-commands --setting-sources='' --system-prompt=''"
 
-[pre-start]
+[[pre-start]]
 symlink-env = """
 main_dir="{{ primary_worktree_path }}"
 find "$main_dir" -maxdepth 5 -name '.env' -o -name '.env.local' | while read -r src; do
@@ -14,6 +14,8 @@ find "$main_dir" -maxdepth 5 -name '.env' -o -name '.env.local' | while read -r 
   ln -sf "$src" "$rel"
 done
 """
+
+[[pre-start]]
 claude-settings = """
 main_dir="{{ primary_worktree_path }}"
 if [ -f "$main_dir/.claude/settings.local.json" ]; then


### PR DESCRIPTION
## Summary
- worktrunk 0.48.0 で `[pre-start]` の table 形式が deprecated 警告を出すようになったため、`[[pre-start]]` (array of tables) 形式へ移行
- `symlink-env` / `claude-settings` を別々の `[[pre-start]]` ブロックに分離

## Test plan
- [x] `wt config update --print --config packages/worktrunk/.config/worktrunk/config.toml` の出力が空（migration 不要）であることを確認
- [x] `wt config show` で deprecation 警告が出ないことを確認
- [x] `npx prettier@3 --check packages/worktrunk/.config/worktrunk/config.toml` が通ることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)