### PR TITLE
chore(git): track .claude config except local/secret files

### DIFF
--- a/packages/git/.gitignore_global
+++ b/packages/git/.gitignore_global
@@ -38,4 +38,9 @@ Temporary Items
 
 .envrc
 mise.toml
-.claude
+
+# Claude Code: 個人マシン固有・機密ファイルのみ除外し、共有設定 (.claude/settings.json,
+# CLAUDE.md 等) はプロジェクトごとに track できるようにする
+.claude/settings.local.json
+.claude/.credentials.json
+CLAUDE.local.md


### PR DESCRIPTION
## Summary

- グローバル gitignore (`packages/git/.gitignore_global`) で `.claude` を丸ごと除外していたのを撤回し、各プロジェクトで `.claude/settings.json` や `.claude/CLAUDE.md` 等の共有設定を track できるようにする。
- 代わりに、マシン固有・機密ファイルのみを除外する一般的な Claude Code 向けパターンを採用:
  - `.claude/settings.local.json` — per-machine 上書き
  - `.claude/.credentials.json` — Claude Code が書き込む認証情報
  - `CLAUDE.local.md` — 個人ノート

## Why

`.claude` 一括除外は事故防止としては機械的だが、`.claude/` の大半は共有可能な設定 (settings.json, CLAUDE.md, commands/, agents/, skills/) であり、プロジェクト単位で commit したいケースを塞いでしまっていた。runtime / cache 系のファイルは基本的に `~/.claude/` 側に出るため、global gitignore で塞ぐ必要は薄い。

参考にした一般的パターン:
- [Should .claude Be in Gitignore? Best Practices](https://claudecodeguides.com/claude-code-gitignore-best-practices/)
- [Organizing Personal and Project Settings in Claude Code | egghead.io](https://egghead.io/organizing-personal-and-project-settings-in-claude-code~q7qsw)
- [The Register: Claude Code ignores ignore rules meant to block secrets](https://www.theregister.com/2026/01/28/claude_code_ai_secrets_files/) — `.credentials.json` を global で塞いでおく根拠

## Test plan

- [x] `npx prettier@3 --check .` 成功
- [x] `git diff` で意図通り 3 パターンのみ追加されていることを確認
- [ ] merge 後、`~/.gitignore_global` (main worktree への symlink) に変更が反映されること
- [ ] 別プロジェクトで `.claude/settings.json` を `git add` できること、`.claude/settings.local.json` は ignore されることを動作確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)