### PR TITLE
fix(makefile): make update で brew bundle 前に brew update を実行する

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,8 @@ help: ## Show this help
 install: ## Run install.sh to setup dotfiles
 	./install.sh
 
-update: ## Update Homebrew packages from Brewfile
+update: ## Update Homebrew itself and packages from Brewfile
+	brew update
 	brew bundle --file=Brewfile
 
 sync: ## Sync current Homebrew packages to Brewfile


### PR DESCRIPTION
## 背景

`make update` 実行時に Homebrew 5.1.9 のバグで以下のエラーが発生した。

```
Error: undefined method 'to_sym' for nil
/opt/homebrew/Library/Homebrew/api/cask/cask_struct_generator.rb:100:in 'block in Homebrew::API::Cask::CaskStructGenerator.process_depends_on'
...
\`brew bundle\` failed! Failed to fetch pipx, uv, awscli, wezterm, visual-studio-code, flutter, rectangle, alt-tab, inkscape, logi-options+, deepl, lightpanda-io/browser/lightpanda, discord, zoom, figma
```

これは Homebrew 本体のバグで [Homebrew/brew#22165](https://github.com/Homebrew/brew/issues/22165) として報告済み、5.1.10 で修正されている。

`brew bundle` は Homebrew 本体や cask metadata の更新を行わないため、Homebrew 本体が古いまま `make update` を実行すると同種の問題を踏むリスクがある。

## 変更内容

`make update` ターゲットで `brew bundle` の実行前に `brew update` を実行するようにした。これにより Homebrew 本体と formulae / cask metadata が最新化された状態でパッケージ同期が走る。

## 検証

- `make help` でターゲット一覧と説明文が正しく表示されることを確認
- `npx prettier@3 --check .` 通過
- ローカルで `brew update` により 5.1.10 へ更新したところ、エラーが出ていた `brew info --cask alt-tab` 等が正常に動作することを確認