### PR TITLE
chore: remove cwt and main-branch claude wrapper

### DIFF
--- a/packages/zsh/.zshrc
+++ b/packages/zsh/.zshrc
@@ -78,29 +78,9 @@ function claude() {
   local branch=$(git branch --show-current 2>/dev/null)
   if [ "$branch" = "main" ] || [ "$branch" = "master" ]; then
     command claude --append-system-prompt \
-      "現在mainブランチにいます。このセッションではコードの変更やgit操作（checkout, commit, branch作成等）を行わないでください。issue起票、アーキテクチャ議論、調査、レビューなど、コード変更を伴わないタスクのみ対応してください。実装が必要な場合はissueを作成するか、ユーザーにcwtコマンドの使用を提案してください。" \
+      "現在mainブランチにいます。このセッションではコードの変更やgit操作（checkout, commit, branch作成等）を行わないでください。issue起票、アーキテクチャ議論、調査、レビューなど、コード変更を伴わないタスクのみ対応してください。実装が必要な場合はissueを作成するか、worktree-start skillでworktreeを切ってから作業を開始してください。" \
       "$@"
   else
     command claude "$@"
   fi
-}
-
-# cwt: claude worktree - タスクからブランチ名を決定しworktreeを作成して対話開始
-function cwt() {
-  local task="$*"
-  if [ -z "$task" ]; then
-    echo "Usage: cwt <タスクの説明>"
-    return 1
-  fi
-
-  echo "ブランチ名を決定中..."
-  local branch=$(command claude -p "以下のタスクに適切なgitブランチ名を1つだけ出力して。命名規則: feature/xxx, fix/xxx, docs/xxx。英語ケバブケース。ブランチ名のみ出力。タスク: $task" | tr -d '`' | xargs)
-
-  if [ -z "$branch" ]; then
-    echo "ブランチ名の決定に失敗しました"
-    return 1
-  fi
-
-  echo "ブランチ: $branch"
-  wt switch --create "$branch" --execute=claude -- "$task"
 }

--- a/packages/zsh/.zshrc
+++ b/packages/zsh/.zshrc
@@ -72,15 +72,3 @@ eval "$(git wt --init zsh)"
 
 # worktrunk (git worktree manager)
 eval "$(wt config shell init zsh)"
-
-# claude: mainブランチではコード変更を行わないセッションとして起動
-function claude() {
-  local branch=$(git branch --show-current 2>/dev/null)
-  if [ "$branch" = "main" ] || [ "$branch" = "master" ]; then
-    command claude --append-system-prompt \
-      "現在mainブランチにいます。このセッションではコードの変更やgit操作（checkout, commit, branch作成等）を行わないでください。issue起票、アーキテクチャ議論、調査、レビューなど、コード変更を伴わないタスクのみ対応してください。実装が必要な場合はissueを作成するか、worktree-start skillでworktreeを切ってから作業を開始してください。" \
-      "$@"
-  else
-    command claude "$@"
-  fi
-}


### PR DESCRIPTION
## 概要

issuekit [PR #15](https://github.com/hirokisakabe/issuekit/pull/15) で `cwt` 代替の `worktree-start` skill が追加されたのを機に、`packages/zsh/.zshrc` の cwt 関連 shell wrapper 群を一掃する。

## 主な変更

- **`cwt()` 関数を削除** — `wt switch --create ... --execute=claude` で worktree を作成し claude を起動するシェル関数。同等機能は issuekit の `worktree-start` skill が `EnterWorktree` ツール経由で提供する。
- **`claude()` wrapper を削除** — main ブランチで `claude` を起動した際にコード変更を抑止する system prompt を注入していたが、`worktree-start` / `issue-implement` skill の description で同等の誘導が効くため、全 main セッションに常時 prompt を注入する必要がなくなった。

## ローカル検証手順

- [x] `npx prettier@3 --check packages/zsh/.zshrc` が通ること。
- [x] `grep -n "cwt" packages/zsh/.zshrc` で残存参照がないこと。
- [ ] `make link` で `~/.zshrc` のシンボリックリンクが更新されること。
- [ ] 新規シェルで `cwt` および `claude` 関数が undefined となり、`claude` 実行時は素の CLI が呼ばれること。