### PR TITLE
chore: claude CLAUDE.md をスリム化

### DIFF
--- a/packages/claude/.claude/CLAUDE.md
+++ b/packages/claude/.claude/CLAUDE.md
@@ -1,29 +1,11 @@
 # Claude Code Configuration
 
-## YOU MUST:
+## Git ワークフロー
 
-- そのプロジェクトにフォーマッタやリンターが設定されている場合、チェックが成功することを確認して、コーディング完了としてください。
-  - 例えば、package.json がある場合は、npm scripts を確認し、必要なコマンドの結果を確認してください。
-
-### Git ワークフロー（常時適用）
-
-- コミット前に lint/fmt などが通ることを確認する
 - PR の description は日本語で記載する
 - ユーザーから明示的に issue 番号を指定された場合のみ、PR description の先頭に `close #<issue番号>` を記載する
 
-> issue 起点の実装サイクル（Status 確認 → cross-review → commit → PR → CI 確認）は `issue-implement` skill に委譲する。サイクル固有の手順は本ファイルに記載しない。
-
-### ブラウザ操作（Lightpanda + agent-browser）
-
-ブラウザ操作は `agent-browser` Skill を `--engine lightpanda` 付きで使用する。
-
-```bash
-agent-browser --engine lightpanda <command>
-```
-
-詳細は `~/.claude/skills/agent-browser/SKILL.md` を参照。
-
-### 最新情報の参照
+## 最新情報の参照
 
 - バージョン・仕様・状況が変わりうる技術トピックは、知識ベースで答えず WebSearch / WebFetch で必ず確認する。
 - ユーザー発話に「最新」「現在」「公式」「リリース」等のキーワードが含まれる場合は検索必須。


### PR DESCRIPTION
## Summary

- `issue-implement` skill 側で lint/fmt 通過がカバーされるため、CLAUDE.md の lint/fmt チェック指示（重複していた 2 箇所）を削除
- ブラウザ操作セクションを削除（lightpanda は制約が多く採用しないため、`agent-browser` skill の description だけで十分）
- 「issue 起点サイクルは issue-implement skill に委譲する」旨の注釈を削除（skill 側で自動的にトリガーされるため CLAUDE.md に書く必要がない）
- 結果として「Git ワークフロー」「最新情報の参照」の 2 セクションだけ残る形に整理

## Test plan

- [ ] `npx prettier@3 --check .` が通ることを確認済み
- [ ] `make link` でシンボリックリンクが従来通り張られることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)