### PR TITLE
chore: disable copilot cli copy-on-select

### DIFF
--- a/packages/copilot/.copilot/settings.json
+++ b/packages/copilot/.copilot/settings.json
@@ -1,5 +1,6 @@
 {
   "theme": "auto",
+  "copyOnSelect": false,
   "allowedUrls": [
     "github.com",
     "raw.githubusercontent.com",


### PR DESCRIPTION
## Summary
- `packages/copilot/.copilot/settings.json` に `"copyOnSelect": false` を追加し、マウス選択時の自動クリップボードコピーを無効化する。
- 以後のコピーは Cmd+C で明示的に行う運用に統一する（macOS のデフォルトは `true`）。

## Test plan
- [ ] `make link` 後、`~/.copilot/settings.json` の内容にこの設定が反映されていること
- [ ] Copilot CLI 起動中にテキストをマウス選択しても自動コピーされないこと
- [ ] Cmd+C でコピーが行えること

🤖 Generated with [Claude Code](https://claude.com/claude-code)