### PR TITLE
chore: set NPM_CONFIG_MIN_RELEASE_AGE=7 in zsh

### DIFF
--- a/packages/zsh/.zshrc
+++ b/packages/zsh/.zshrc
@@ -67,6 +67,10 @@ complete -o nospace -C /opt/homebrew/bin/terraform terraform
 # mise
 eval "$(/opt/homebrew/bin/mise activate zsh)"
 
+# npm: publish 直後の悪意あるバージョン取り込みを避けるため、7日経過したバージョンのみ install 対象とする
+# 要 npm >= 11.10.0
+export NPM_CONFIG_MIN_RELEASE_AGE=7
+
 # git-wt (git worktree helper)
 eval "$(git wt --init zsh)"
 


### PR DESCRIPTION
## Summary

- npm の `min-release-age` 設定 ([npm CLI 11.10.0](https://github.com/npm/cli/releases/tag/v11.10.0) で導入) を環境変数経由で有効化
- `packages/zsh/.zshrc` に `export NPM_CONFIG_MIN_RELEASE_AGE=7` を追記し、publish から 7 日経過したバージョンのみ install されるようにする
- サプライチェーン攻撃 (publish 直後に悪意あるバージョンが拡散される系) の緩和が目的

`~/.npmrc` は registry の auth token を含むため dotfiles 管理しない方針とし、環境変数で設定する形を選択。

## Test plan

- [ ] `make link` 後に `source ~/.zshrc` し、`echo $NPM_CONFIG_MIN_RELEASE_AGE` が `7` を返すこと
- [ ] `npm config get min-release-age` が `7` を返すこと (npm >= 11.10.0 が必要)

🤖 Generated with [Claude Code](https://claude.com/claude-code)