### PR TITLE
chore: enable copilot cli footer items

### DIFF
--- a/packages/copilot/.copilot/settings.json
+++ b/packages/copilot/.copilot/settings.json
@@ -1,6 +1,14 @@
 {
   "theme": "auto",
   "copyOnSelect": false,
+  "footer": {
+    "showDirectory": true,
+    "showBranch": true,
+    "showContextUsed": true,
+    "showQuota": true,
+    "showAgent": true,
+    "showEffort": true
+  },
   "allowedUrls": [
     "github.com",
     "raw.githubusercontent.com",


### PR DESCRIPTION
## 概要

Copilot CLI の footer (statusline) に Claude Code 相当の情報を出すよう設定する。

## 変更内容

`packages/copilot/.copilot/settings.json` に `footer` セクションを追加し、以下を有効化:

- `showDirectory` — カレントディレクトリ
- `showBranch` — git branch (Claude の `(branch)` 相当)
- `showContextUsed` — コンテキスト使用率 (Claude の token usage % 相当)
- `showQuota` — 残量 (Claude の 5h rate limit 相当)
- `showAgent` — 実行中の agent 名
- `showEffort` — model effort レベル

## 検討メモ

当初は Claude Code と同じ形式の文字列を出すため `statusLine.command` で custom script を渡す方針を試したが、copilot-cli v1.0.47 時点では [github/copilot-cli#3192](https://github.com/github/copilot-cli/issues/3192) の bug でスクリプトが実行されない状態だった。built-in の footer 項目で必要な情報は揃うため、custom script (`statusline.sh`) と `feature_flags` / `experimental` 系の設定は今回入れず、built-in 項目のみで構成した。

## 動作確認

- `make link` 済みで `~/.copilot/settings.json` は symlink 経由で反映
- `copilot` 起動後、footer に `~/work/dotfiles [⎇ main*%]` ... `Remaining reqs.: 86%` が表示されることを確認
- `npx prettier@3 --check packages/copilot/.copilot/settings.json` 通過