### PR TITLE
chore: set Claude Code default model to opusplan

### DIFF
--- a/packages/claude/.claude/settings.json
+++ b/packages/claude/.claude/settings.json
@@ -140,5 +140,6 @@
   "language": "ja",
   "voiceEnabled": true,
   "skipAutoPermissionPrompt": true,
-  "tui": "default"
+  "tui": "default",
+  "model": "opusplan"
 }


### PR DESCRIPTION
## Summary

- Claude Code のデフォルトモデルを `opusplan` に設定
- Plan mode 中は Opus 4.7、実装フェーズは Sonnet 4.6 に自動切替する hybrid モード
- 全 Opus 運用に比べ 5h レート上限の消費を抑えつつ、計画フェーズの推論品質は維持する狙い

## Background

- 現状すべてのリクエストを Opus に投げており、Max 5x プランの 5h 上限に張り付くケースが続いていた
- 2026/4/16 リリースの Opus 4.7 は新トークナイザで最大 35% トークン増 → 全 Opus はさらに上限消費が早い
- 公式推奨パターン "Plan with Opus, execute with Sonnet" を `opusplan` alias で自動化できる

## Notes

- 反映タイミング: **次回 Claude Code 起動時から**
- 過去に `/model` で別モデルを選択している場合、`settings.local.json` の値が優先される。確認するなら `/model default` で一旦クリア
- 1M context の自動アップグレードは `opusplan` には適用されず、Plan phase の Opus も標準 200K context で動作する

## Test plan

- [ ] `make link` 済みで `~/.claude/settings.json` の symlink が dotfiles 側を指していることを確認
- [ ] 新規 Claude Code セッションで `/status` を実行し、モデルが `opusplan` になっていることを確認
- [ ] Plan mode (`Shift+Tab`) で Opus 4.7 に切り替わることを確認
- [ ] Plan を抜けると Sonnet 4.6 で実装が走ることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)