### PR TITLE
[codex] Codex の status line 設定を追加

### DIFF
--- a/packages/codex/.codex/config.toml
+++ b/packages/codex/.codex/config.toml
@@ -1,0 +1,21 @@
+model = "gpt-5.5"
+model_reasoning_effort = "medium"
+personality = "pragmatic"
+
+[features]
+runtime_metrics = true
+
+[tui]
+status_line = [
+  "model-with-reasoning",
+  "git-branch",
+  "context-used",
+  "input-token-usage",
+  "output-token-usage",
+  "five-hour-limit",
+  "weekly-limit",
+]
+status_line_use_colors = true
+
+[tui.model_availability_nux]
+"gpt-5.5" = 4


### PR DESCRIPTION
## 概要

Codex CLI の設定ファイルを dotfiles 管理に追加し、Claude Code と同じようにセッション状態を見やすくするための status line 表示を設定しました。

## 変更内容

- `packages/codex/.codex/config.toml` を追加
- `runtime_metrics` feature を有効化
- Codex TUI の status line に以下を表示
  - モデル名と reasoning level
  - Git branch
  - context 使用率
  - input/output token usage
  - 5-hour / weekly limit
- ローカル cache / marketplace / hook state / project trust 由来の絶対パス設定は含めず、status line に必要な最小構成に整理

## 影響

`make link` または Stow により `~/.codex/config.toml` が dotfiles 管理になり、Codex 起動時に context 状態や token 使用量などが status line に表示されます。

## 確認

- `codex debug prompt-input test`
- `codex features list` で `runtime_metrics` が `true` になっていることを確認
- `cd packages && stow -nv --no-folding -t ~ codex`
- `make help`
- `rg -n "/Users/|/private/|\\.cache|marketplaces|hooks\\.state|source =|projects\\." packages/codex/.codex/config.toml` で該当なし

補足: commit 時に `lefthook` が PATH にない警告は出ましたが、commit は正常に作成されています。