### PR TITLE
chore: add codex sandbox defaults

### DIFF
--- a/packages/codex/.codex/config.toml
+++ b/packages/codex/.codex/config.toml
@@ -1,9 +1,14 @@
 model = "gpt-5.5"
 model_reasoning_effort = "medium"
 personality = "pragmatic"
+approval_policy = "on-request"
+sandbox_mode = "workspace-write"
 
 [features]
 runtime_metrics = true
+
+[sandbox_workspace_write]
+network_access = true
 
 [tui]
 status_line = [
@@ -19,3 +24,6 @@ status_line_use_colors = true
 
 [tui.model_availability_nux]
 "gpt-5.5" = 4
+
+[projects."/Users/hirokisakabe/work/dotfiles"]
+trust_level = "trusted"


### PR DESCRIPTION
## 目的

Codex の普段使い向けに、sandbox と approval の既定値を明示します。

## 変更内容

- `approval_policy = "on-request"` を追加
- `sandbox_mode = "workspace-write"` を追加
- `workspace-write` sandbox でのネットワークアクセスを許可
- dotfiles repo を trusted project として明示

## 動作確認

- `python3` の `tomllib` で `packages/codex/.codex/config.toml` を読み込み確認
- `git diff --check`