### PR TITLE
feat: pnpm の minimumReleaseAge を dotfiles で管理する

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 .PHONY: install update sync link unlink clean-legacy-claude-skills-stow setup-mcp skills-install promote-webfetch help
 
-PACKAGES := zsh vim wezterm git npm starship yazi bat tig lazygit claude codex copilot worktrunk gh-dash gram mise
+PACKAGES := zsh vim wezterm git npm starship yazi bat tig lazygit claude codex copilot worktrunk gh-dash gram mise pnpm
 
 help: ## Show this help
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-15s\033[0m %s\n", $$1, $$2}'

--- a/packages/pnpm/Library/Preferences/pnpm/config.yaml
+++ b/packages/pnpm/Library/Preferences/pnpm/config.yaml
@@ -1,0 +1,1 @@
+minimumReleaseAge: 10080


### PR DESCRIPTION
close #303

## 目的

pnpm のサプライチェーン攻撃対策として `minimumReleaseAge: 10080`（7日 = 10080分）を `packages/pnpm/Library/Preferences/pnpm/config.yaml` で管理し、`make link` 後に全 pnpm プロジェクトへ自動適用できるようにする。

## 変更内容

- `packages/pnpm/Library/Preferences/pnpm/config.yaml` を新規作成し、`minimumReleaseAge: 10080` を設定
- `Makefile` の `PACKAGES` 変数に `pnpm` を追加して stow 対象に追加

## 影響パッケージパス

- `packages/pnpm/` （新規追加）
- `Makefile`

## ローカル検証手順

```bash
# シンボリックリンクの作成確認
make link

# リンク先の確認
readlink ~/Library/Preferences/pnpm/config.yaml

# pnpm での設定反映確認（pnpm 11 以降が必要）
pnpm config get minimumReleaseAge
# → 10080
```

> **注意**: `config.yaml` 形式は pnpm 11 以降の機能です。pnpm 10 以前では `pnpm config get minimumReleaseAge` は `undefined` を返しますが、pnpm 11 にアップグレード後は正しく `10080` が返ります。