### PR TITLE
feat: gh-dependabot 拡張を導入して全リポジトリの Dependabot アラートを一覧確認できるようにする

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -20,6 +20,7 @@ make link
 
 printf '\n-- install gh extensions --\n'
 gh extension install dlvhdr/gh-dash || true
+gh extension install steiza/gh-dependabot || true
 
 printf '\n-- install GitAlias --\n'
 echo "Downloading GitAlias..."


### PR DESCRIPTION
close #304

## 目的

`steiza/gh-dependabot` gh 拡張を `install.sh` に追加し、`gh dependabot alerts` 一コマンドで全リポジトリの Dependabot アラートを横断確認できるようにする。

GitHub の `/user/dependabot/alerts` API は個人アカウントに存在しないため、リポジトリごとにループして取得する必要があった問題を解消する。

## 変更内容

- `install.sh`: gh extension インストールブロックに `gh extension install steiza/gh-dependabot || true` を追加

## 影響パッケージ

- `install.sh`（gh extensions インストールブロック）

## ローカル検証手順

1. `install.sh` に `gh extension install steiza/gh-dependabot` が含まれていることを確認
2. `gh extension install steiza/gh-dependabot` を手動実行し、インストール成功を確認
3. `gh dependabot alerts` を実行し、全リポジトリの open な Dependabot アラートが一覧表示されることを確認