### PR TITLE
feat: Homebrew のセキュリティ関連環境変数を zshrc に追加する

### DIFF
--- a/packages/zsh/.zshrc
+++ b/packages/zsh/.zshrc
@@ -1,4 +1,7 @@
 eval "$(/opt/homebrew/bin/brew shellenv)"
+export HOMEBREW_NO_ANALYTICS=1
+export HOMEBREW_NO_INSECURE_REDIRECT=1
+export HOMEBREW_CASK_OPTS="--require-sha"
 export PATH="$HOME/.local/bin:$PATH"
 
 fpath+=("/opt/homebrew/share/zsh/site-functions")


### PR DESCRIPTION
close #308

## 目的

`packages/zsh/.zshrc` の Homebrew 初期化直後に、セキュリティ強化のための環境変数 3 つを追加する。

## 変更内容

- **`HOMEBREW_NO_ANALYTICS=1`**: Homebrew のテレメトリ（使用状況データ収集）を無効化
- **`HOMEBREW_NO_INSECURE_REDIRECT=1`**: HTTP リダイレクトを拒否し、中間者攻撃（MITM）を防御
- **`HOMEBREW_CASK_OPTS="--require-sha"`**: cask インストール時に SHA チェックサムを必須化し、改ざんを検知

## 影響パッケージパス

- `packages/zsh/.zshrc`

## ローカル検証手順

```sh
make link
# 新規シェルで確認
echo $HOMEBREW_NO_ANALYTICS        # → 1
echo $HOMEBREW_NO_INSECURE_REDIRECT # → 1
echo $HOMEBREW_CASK_OPTS           # → --require-sha
```