### PR TITLE
revert: install.sh から gh-dependabot 拡張を削除する

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -20,7 +20,6 @@ make link
 
 printf '\n-- install gh extensions --\n'
 gh extension install dlvhdr/gh-dash || true
-gh extension install steiza/gh-dependabot || true
 
 printf '\n-- install GitAlias --\n'
 echo "Downloading GitAlias..."


### PR DESCRIPTION
## 概要

スター数が少なく動作も不安定だったため、`install.sh` から `steiza/gh-dependabot` 拡張のインストール行を削除する。

## 変更内容

- `install.sh`: `gh extension install steiza/gh-dependabot || true` を削除

## 確認手順

- `make help` でMakefile整合性に問題がないことを確認
- `install.sh` に該当行が残っていないことを確認