### PR TITLE
feat: atuin をシェル履歴ツールとして導入する

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -10,6 +10,7 @@ tap "lightpanda-io/browser"
 # --- Shell & Environment ---
 brew "zsh"
 brew "zsh-autosuggestions"
+brew "atuin"
 brew "zsh-fast-syntax-highlighting"
 brew "starship"
 brew "direnv"

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 .PHONY: install update sync link unlink clean-legacy-claude-skills-stow setup-mcp skills-install promote-webfetch help
 
-PACKAGES := zsh vim wezterm git npm starship yazi bat tig lazygit claude codex copilot worktrunk gh-dash gram mise pnpm
+PACKAGES := zsh vim wezterm git npm starship yazi bat tig lazygit claude codex copilot worktrunk gh-dash gram mise pnpm atuin
 
 help: ## Show this help
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-15s\033[0m %s\n", $$1, $$2}'

--- a/packages/atuin/.config/atuin/config.toml
+++ b/packages/atuin/.config/atuin/config.toml
@@ -1,0 +1,13 @@
+auto_sync = false
+update_check = false
+
+search_mode = "fuzzy"
+filter_mode = "global"
+workspaces = true
+
+style = "compact"
+enter_accept = true
+show_preview = true
+
+secrets_filter = true
+store_failed = true

--- a/packages/zsh/.zshrc
+++ b/packages/zsh/.zshrc
@@ -79,3 +79,6 @@ eval "$(git wt --init zsh)"
 
 # worktrunk (git worktree manager)
 eval "$(wt config shell init zsh)"
+
+# atuin
+eval "$(atuin init zsh)"


### PR DESCRIPTION
## 目的

シェル履歴管理ツール [atuin](https://atuin.sh/) を導入する。SQLite バックエンドによる fuzzy 検索・Git ワークスペース対応の履歴フィルタリングを追加する。

## 変更内容

| ファイル | 内容 |
|---|---|
| `Brewfile` | `brew "atuin"` を Shell & Environment セクションに追加 |
| `Makefile` | `PACKAGES` に `atuin` を追加（`make link` 対象） |
| `packages/zsh/.zshrc` | `eval "$(atuin init zsh)"` を末尾に追加 |
| `packages/atuin/.config/atuin/config.toml` | 新規作成 |

### config.toml の主な設定

- `auto_sync = false` / `update_check = false` — sync・更新確認なし
- `workspaces = true` — Git リポジトリ内では自動的にそのリポジトリの履歴に絞り込み
- `enter_accept = true` — Enter で即実行（`Tab` で編集に移れる）
- `filter_mode = "global"` — デフォルトは全履歴表示、UI 内で `Ctrl+F` 切り替え可
- `secrets_filter = true` — API キー等を自動フィルタリング

## ローカル検証手順

```sh
brew install atuin
make link
# 新しいシェルセッションを開いて Ctrl+R で atuin が起動することを確認
```

インストール後、`make sync` を実行すると `Brewfile.lock.json` に atuin が反映される。