### PR TITLE
chore: 削除パッケージの関連設定ファイルを除去する

### DIFF
--- a/packages/claude/.claude/settings.json
+++ b/packages/claude/.claude/settings.json
@@ -74,7 +74,6 @@
       "WebFetch(domain:gist.github.com)",
       "WebFetch(domain:hub-lac-phi.vercel.app)",
       "WebFetch(domain:knip.dev)",
-      "WebFetch(domain:lightpanda.io)",
       "WebFetch(domain:lovable.dev)",
       "WebFetch(domain:medium.com)",
       "WebFetch(domain:nextjs.org)",

--- a/packages/copilot/.copilot/settings.json
+++ b/packages/copilot/.copilot/settings.json
@@ -38,7 +38,6 @@
     "frontendmasters.com",
     "hub-lac-phi.vercel.app",
     "knip.dev",
-    "lightpanda.io",
     "lovable.dev",
     "medium.com",
     "nextjs.org",

--- a/packages/yazi/.config/yazi/yazi.toml
+++ b/packages/yazi/.config/yazi/yazi.toml
@@ -9,7 +9,7 @@ max_height = 1000  # プレビューの最大高さ
 
 [opener]
 edit = [
-  { run = 'nvim "$@"', block = true, for = "unix" },
+  { run = 'vim "$@"', block = true, for = "unix" },
 ]
 
 [plugin]


### PR DESCRIPTION
## 概要

前の PR (#315) で Brewfile から削除したパッケージの残存設定を除去した。

## 変更内容

- `packages/claude/.claude/settings.json` — `lightpanda.io` の WebFetch パーミッションを削除
- `packages/copilot/.copilot/settings.json` — `lightpanda.io` を allowedUrls から削除
- `packages/yazi/.config/yazi/yazi.toml` — エディタを `nvim` → `vim` に変更（neovim 削除に伴う対応）

なお `.claude/settings.local.json` は `.gitignore` 対象のため、同ファイルの asana / gram / lightpanda パーミッション行はローカルでのみ削除済み。

## 確認手順

- `make link` でシンボリックリンクが正常に展開されることを確認