### PR TITLE
chore: 削除パッケージの関連設定ファイルを除去する

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 .PHONY: install update sync link unlink clean-legacy-claude-skills-stow setup-mcp skills-install promote-webfetch help
 
-PACKAGES := zsh vim wezterm git npm starship yazi bat tig lazygit claude codex copilot worktrunk gh-dash gram mise pnpm atuin
+PACKAGES := zsh vim wezterm git npm starship yazi bat tig lazygit claude codex copilot worktrunk gh-dash mise pnpm atuin
 
 help: ## Show this help
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-15s\033[0m %s\n", $$1, $$2}'
@@ -45,7 +45,6 @@ skills-install: ## Install agent skills globally via skills.sh
 
 setup-mcp: ## Setup MCP servers for Claude Code
 	-claude mcp add --scope user --transport stdio chrome-devtools -- npx chrome-devtools-mcp@latest
-	-claude mcp add --scope user --transport http asana https://mcp.asana.com/mcp
 
 promote-webfetch: ## Promote WebFetch domains from history to permissions.allow
 	./scripts/promote-webfetch.sh


### PR DESCRIPTION
## 概要

前の PR (#315, #316) で削除したパッケージの残存記述を Makefile から除去した。

## 変更内容

- `PACKAGES` から `gram` を削除（`packages/gram/` は #315 で削除済み）
- `setup-mcp` ターゲットから asana MCP サーバーのセットアップ行を削除

## 確認手順

- `make help` で Makefile が正常に動作することを確認
- `make link` でシンボリックリンクが正常に展開されることを確認