### PR TITLE
fix: npx 不在時に skills-install で make link を失敗させない

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,10 +37,13 @@ clean-legacy-claude-skills-stow: ## Remove old Stow links for legacy Claude Code
 	fi
 
 skills-install: ## Install agent skills globally via skills.sh
-	@command -v npx >/dev/null 2>&1 || { echo "npx not found on PATH; skipping skills install (install Node via mise first)" >&2; exit 0; }
-	npx -y skills@latest add hirokisakabe/issuekit --global -y
-	npx -y skills@latest add anthropics/skills --skill frontend-design --global -y
-	npx -y skills@latest add anthropics/skills --skill skill-creator --global -y
+	@if ! command -v npx >/dev/null 2>&1; then \
+		echo "npx not found on PATH; skipping skills install (install Node via mise first)" >&2; \
+		exit 0; \
+	fi; \
+	npx -y skills@latest add hirokisakabe/issuekit --global -y && \
+	npx -y skills@latest add anthropics/skills --skill frontend-design --global -y && \
+	npx -y skills@latest add anthropics/skills --skill skill-creator --global -y && \
 	npx -y skills@latest add vercel-labs/agent-browser --global -y
 
 setup-mcp: ## Setup MCP servers for Claude Code


### PR DESCRIPTION
## Summary

- `make link` が `skills-install` ターゲットで `npx` がない時に失敗していた問題を修正
- 既存実装は `command -v npx ... || { echo ...; exit 0; }` で skip しようとしていたが、Makefile の各レシピ行は別シェルで実行されるため `exit 0` は最初の行を抜けるだけで、次の `npx ...` 行が実行されて非0で落ちていた
- check と npx 呼び出しを `if`/`fi` と `&&` で 1 つのレシピ行に統合し、npx 不在時は正しく skip して exit 0 する

## Test plan

- [x] `make link` が npx 不在の環境で skip メッセージを出して exit 0 する
- [ ] mise activate 済みの通常 zsh ターミナルから `make link` を実行し、skills インストールが実際に走ることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)