### PR TITLE
feat: gh-infra を導入する

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -20,6 +20,7 @@ make link
 
 printf '\n-- install gh extensions --\n'
 gh extension install dlvhdr/gh-dash || true
+gh extension install babarot/gh-infra || true
 
 printf '\n-- install GitAlias --\n'
 echo "Downloading GitAlias..."


### PR DESCRIPTION
close #320

## 概要

`install.sh` に `gh extension install babarot/gh-infra` を追加する。

YAML で GitHub リポジトリ設定（ブランチ保護・コラボレーター・webhook など）を宣言的に管理する gh extension `babarot/gh-infra` を導入する。

## 変更内容

- `install.sh`: `-- install gh extensions --` セクションに `gh extension install babarot/gh-infra || true` を追加

## ローカル検証手順

```bash
gh extension install babarot/gh-infra
gh infra --help
```