### PR TITLE
chore: mise の node/python を完全固定する

### DIFF
--- a/packages/mise/.config/mise/config.toml
+++ b/packages/mise/.config/mise/config.toml
@@ -1,6 +1,6 @@
 [tools]
-node = "latest"
-python = "latest"
+node = "24.16.0"
+python = "3.14.5"
 
 [settings]
 idiomatic_version_file_enable_tools = ["python", "node"]


### PR DESCRIPTION
## Summary

- `packages/mise/.config/mise/config.toml` の `node` / `python` を `"latest"` から完全固定 (`node = "24.16.0"`, `python = "3.14.5"`) に変更
- dotfiles の他パッケージ (Brewfile.lock.json 等) と同じく「複数環境で同じバージョンを再現する」方針に揃える

## Why

`latest` 指定は **mise が初回解決した時点のバージョン** で固定され、自動的には更新されない。実環境では node 24.9.0 (npm 11.6.0) のまま据え置かれており、npm 11.10 で導入された `NPM_CONFIG_MIN_RELEASE_AGE` (zshrc で export 済) が認識されず warning が出ていた。

`"latest"` を残すと:
- いつ何のバージョンが入ったか git log から追えない
- 「latest だと思っていたら半年前の latest だった」事故が起きる
- 新しい Mac で dotfiles を clone した時に別バージョンが入る

完全固定にすれば再現性が確保でき、バージョン更新は明示的な commit として残る (Brewfile と同じ運用)。

## Trade-off

node / python の security update / 新機能取り込みは手動バンプが必要になる。これは Brewfile も同様で、`make update` 系の運用と揃う想定。

## Test plan

- [ ] worktree 内で `mise install` が成功すること
- [ ] 既存環境で `mise upgrade` 実行後、`node --version` が `v24.16.0`、`python --version` が `Python 3.14.5` を返すこと
- [ ] `npm --version` が `>= 11.10.0` になり `NPM_CONFIG_MIN_RELEASE_AGE` の warning が消えること

🤖 Generated with [Claude Code](https://claude.com/claude-code)