### PR TITLE
feat: socket.dev safe npm をグローバル設定してサプライチェーン保護を行う

### DIFF
--- a/packages/npm/.default-npm-packages
+++ b/packages/npm/.default-npm-packages
@@ -1,3 +1,3 @@
 # mise Default Node Packages
 agent-browser
-@socketsecurity/cli
+socket

--- a/packages/npm/.default-npm-packages
+++ b/packages/npm/.default-npm-packages
@@ -1,2 +1,3 @@
 # mise Default Node Packages
 agent-browser
+@socketsecurity/cli

--- a/packages/zsh/.zshrc
+++ b/packages/zsh/.zshrc
@@ -72,8 +72,9 @@ eval "$(/opt/homebrew/bin/mise activate zsh)"
 export NPM_CONFIG_MIN_RELEASE_AGE=7
 
 # socket.dev safe npm: npm/npx をラップしてサプライチェーン攻撃をインストール前に検知する
-alias npm="socket npm"
-alias npx="socket npx"
+alias npm="socket-npm"
+alias npx="socket-npx"
+compdef _npm socket-npm
 
 # git-wt (git worktree helper)
 eval "$(git wt --init zsh)"

--- a/packages/zsh/.zshrc
+++ b/packages/zsh/.zshrc
@@ -71,6 +71,10 @@ eval "$(/opt/homebrew/bin/mise activate zsh)"
 # 要 npm >= 11.10.0
 export NPM_CONFIG_MIN_RELEASE_AGE=7
 
+# socket.dev safe npm: npm/npx をラップしてサプライチェーン攻撃をインストール前に検知する
+alias npm="socket npm"
+alias npx="socket npx"
+
 # git-wt (git worktree helper)
 eval "$(git wt --init zsh)"
 


### PR DESCRIPTION
close #302

## 概要

`packages/npm/.default-npm-packages` に socket CLI を追加し、`packages/zsh/.zshrc` に `npm` / `npx` を socket でラップする alias を設定する。`make link` 後、新規シェルでの `npm install` / `npx` 実行時に socket.dev によるサプライチェーンチェックが自動で動作する。

## 変更内容

- `packages/npm/.default-npm-packages`: socket CLI を追加
- `packages/zsh/.zshrc`: npm/npx を socket-npm/socket-npx にラップする alias を追加、`compdef _npm socket-npm` で zsh の補完を維持

## 影響パッケージパス

- `packages/npm/`
- `packages/zsh/`

## 受け入れ条件 (issue #302) との対応

issue 本文の受け入れ条件は具体的なリテラル (`@socketsecurity/cli` パッケージ名と `alias npm=\"socket npm\"` というスペース区切りの形式) を指定していたが、cross-review で socket.dev 公式情報を確認した結果、以下の点で公式仕様に合わせる修正を入れている (2 commit 目)。issue の趣旨 (サプライチェーン保護を全リポジトリに自動適用) は満たした上での変更。

- **パッケージ名**: `@socketsecurity/cli` は 2024-10-26 付で公式に `socket` へリネーム済み、旧名は deprecated 予定。([Socket CLI Renamed to \"Socket\" on npm](https://socket.dev/changelog/socket-cli-renamed-to-socket-on-npm))
- **alias 形式**: 公式が手動 alias として案内しているのは `socket-npm` / `socket-npx` (ハイフン区切り) 形式。zsh 補完を維持するため `compdef _npm socket-npm` も追加。([socket npm & socket npx](https://docs.socket.dev/docs/socket-npm-socket-npx))

## ローカル検証手順

- [x] `npx prettier@3 --check .` でフォーマット確認
- [ ] マージ後、ローカルで以下を確認:
  - `make link` で `~/.zshrc` のシンボリックリンクを更新
  - `mise install` (もしくは `mise reshim`) で `socket` を default packages 経由で導入
  - 新規シェルを起動し、任意リポジトリで `npm install` を実行して socket の分析ログが表示されることを確認

## スコープ外

- socket.dev アカウントの作成・認証設定
- CI/CD パイプラインへの適用
- yarn / pnpm / bun への対応