### PR TITLE
fix: socket.dev safe npm の zshrc alias を撤去する

### DIFF
--- a/packages/zsh/.zshrc
+++ b/packages/zsh/.zshrc
@@ -71,11 +71,6 @@ eval "$(/opt/homebrew/bin/mise activate zsh)"
 # 要 npm >= 11.10.0
 export NPM_CONFIG_MIN_RELEASE_AGE=7
 
-# socket.dev safe npm: npm/npx をラップしてサプライチェーン攻撃をインストール前に検知する
-alias npm="socket-npm"
-alias npx="socket-npx"
-compdef _npm socket-npm
-
 # git-wt (git worktree helper)
 eval "$(git wt --init zsh)"
 


### PR DESCRIPTION
close #324

## 概要

PR #323 で導入した `packages/zsh/.zshrc` の socket.dev safe npm 用 alias / compdef を全削除し、`npm` / `npx` を素の挙動に戻す。`socket` パッケージ自体は `packages/npm/.default-npm-packages` に残し、`socket scan` / `socket package score` 等の単体コマンドはそのまま使えるようにする。

## 背景

PR #323 マージ後に `tatami` リポジトリで `npm install` を実行したところ、以下の SyntaxError が発生:

```
/Users/hirokisakabe/.local/share/mise/installs/node/24.16.0/bin/npm:2
set -euo pipefail
         ^^^^^^^^

SyntaxError: Unexpected identifier 'pipefail'
```

### 根本原因

- mise は global install/uninstall 後の `mise reshim` 自動実行のため、`~/.local/share/mise/installs/node/<ver>/bin/npm` を **bash wrapper script** に置き換えている
- socket-cli の `installNpmLinks` (`dist/utils.js:6909`) は PATH 上の `npm` をそのまま `realBinPath` として `node --require <inject> <realBinPath>` で spawn する
- 結果、Node が bash script を JS としてロードして `set -euo pipefail` の行で SyntaxError になる
- `SOCKET_CLI_NPM_PATH` 設定 / `PATH` 操作のいずれでも回避不能なことを検証済み
- 上流 issue [SocketDev/socket-cli#694](https://github.com/SocketDev/socket-cli/issues/694) で `v1.0.69` で fix 済みとされていたが `v1.1.95` でも再発

ローカル wrapper (`socket npm`) は socket.dev 公式ドキュメントでも「保護が必要な場合の選択肢」として位置づけられたオプショナル機能。本リポジトリ (dotfiles) ではローカル wrapper を諦め、`socket` 単体コマンドを必要時に手動で使う運用に切り替える。

## 変更内容

- `packages/zsh/.zshrc`: 以下 4 行を削除
  - `# socket.dev safe npm: npm/npx をラップしてサプライチェーン攻撃をインストール前に検知する`
  - `alias npm="socket-npm"`
  - `alias npx="socket-npx"`
  - `compdef _npm socket-npm`

## 影響パッケージパス

- `packages/zsh/`

## ローカル検証手順

- [x] `npx prettier@3 --check .` でフォーマット確認
- [ ] マージ後、`main` で `make link` を実行し `~/.zshrc` を更新
- [ ] 新規 zsh セッションを起動し、任意リポジトリで `npm install` を実行して SyntaxError が出ないことを確認

## スコープ外

- socket-cli upstream への bug 報告 (今回は行わない方針)
- Socket for GitHub App の導入検討 (リポジトリ側の別タスク)
- CI 統合 (`socket ci` / GitHub Action) の検討 (同上)

## 参考

- 元 PR: #323
- 元 issue: #302
- [SocketDev/socket-cli#694](https://github.com/SocketDev/socket-cli/issues/694)
- [safe-npm FAQ](https://docs.socket.dev/docs/safe-npm-faq)
