### PR TITLE
feat: claude settings に Bash(codex:*) permission を追加する

### DIFF
--- a/packages/claude/.claude/settings.json
+++ b/packages/claude/.claude/settings.json
@@ -62,6 +62,7 @@
       "Bash(pyftsubset:*)",
       "Skill(codex-review)",
       "Skill(agent-browser)",
+      "Bash(codex:*)",
       "Bash(echo:*)",
       "WebFetch(domain:api.github.com)",
       "WebFetch(domain:better-auth.com)",


### PR DESCRIPTION
## 概要

`packages/claude/.claude/settings.json` の `permissions.allow` に `Bash(codex:*)` を追加する。

## 変更内容

- `settings.json` の allow リストに `"Bash(codex:*)"` を追加

## 確認手順

- `make link` でシンボリックリンクを更新後、`~/.claude/settings.json` に反映されることを確認