### PR TITLE
chore: skills インストールを npx skills@latest から gh skill に移行する

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,15 +36,11 @@ clean-legacy-claude-skills-stow: ## Remove old Stow links for legacy Claude Code
 		done; \
 	fi
 
-skills-install: ## Install agent skills globally via skills.sh
-	@if ! command -v npx >/dev/null 2>&1; then \
-		echo "npx not found on PATH; skipping skills install (install Node via mise first)" >&2; \
-		exit 0; \
-	fi; \
-	npx -y skills@latest add hirokisakabe/issuekit --global -y && \
-	npx -y skills@latest add anthropics/skills --skill frontend-design --global -y && \
-	npx -y skills@latest add anthropics/skills --skill skill-creator --global -y && \
-	npx -y skills@latest add vercel-labs/agent-browser --global -y
+skills-install: ## Install agent skills globally via gh skill
+	gh skill install hirokisakabe/issuekit --agent claude-code --scope user -f
+	gh skill install anthropics/skills frontend-design --agent claude-code --scope user -f
+	gh skill install anthropics/skills skill-creator --agent claude-code --scope user -f
+	gh skill install vercel-labs/agent-browser --agent claude-code --scope user -f
 
 setup-mcp: ## Setup MCP servers for Claude Code
 	-claude mcp add --scope user --transport stdio chrome-devtools -- npx chrome-devtools-mcp@latest

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ update: ## Update Homebrew itself and packages from Brewfile
 sync: ## Sync current Homebrew packages to Brewfile
 	brew bundle dump --force --file=Brewfile
 
-link: ## Create symlinks with stow and install agent skills via skills.sh
+link: ## Create symlinks with stow and install agent skills via gh skill
 	$(MAKE) clean-legacy-claude-skills-stow
 	cd packages && stow -v --no-folding -t ~ $(PACKAGES)
 	$(MAKE) skills-install
@@ -37,10 +37,16 @@ clean-legacy-claude-skills-stow: ## Remove old Stow links for legacy Claude Code
 	fi
 
 skills-install: ## Install agent skills globally via gh skill
-	gh skill install hirokisakabe/issuekit --agent claude-code --scope user -f
+	gh skill install hirokisakabe/issuekit acceptance-check --agent claude-code --scope user -f
+	gh skill install hirokisakabe/issuekit cross-review --agent claude-code --scope user -f
+	gh skill install hirokisakabe/issuekit issue-create --agent claude-code --scope user -f
+	gh skill install hirokisakabe/issuekit issue-implement --agent claude-code --scope user -f
+	gh skill install hirokisakabe/issuekit issue-pick --agent claude-code --scope user -f
+	gh skill install hirokisakabe/issuekit issue-refine --agent claude-code --scope user -f
+	gh skill install hirokisakabe/issuekit worktree-start --agent claude-code --scope user -f
 	gh skill install anthropics/skills frontend-design --agent claude-code --scope user -f
 	gh skill install anthropics/skills skill-creator --agent claude-code --scope user -f
-	gh skill install vercel-labs/agent-browser --agent claude-code --scope user -f
+	gh skill install vercel-labs/agent-browser agent-browser --agent claude-code --scope user -f
 
 setup-mcp: ## Setup MCP servers for Claude Code
 	-claude mcp add --scope user --transport stdio chrome-devtools -- npx chrome-devtools-mcp@latest


### PR DESCRIPTION
close #306

## 目的

`make link` 時の skills インストールを `npx -y skills@latest` から `gh skill install` に移行する。
npm サプライチェーンリスクを回避し、バージョン固定・事前確認が可能なインストール手段に切り替える。

## 変更内容

- `Makefile` の `skills-install` ターゲットを `gh skill install` 形式に書き換え
- `--agent claude-code --scope user` を全スキルに明示
- `hirokisakabe/issuekit` の 7 スキルを個別指定（非対話実行時は skill 名が必須）
- `vercel-labs/agent-browser` に skill 名 `agent-browser` を追加
- `npx` の存在チェック（`command -v npx`）を削除
- `link` ターゲットのコメントを `via skills.sh` → `via gh skill` に修正

## 影響パッケージパス

- `Makefile`

## ローカル検証手順

```bash
make help           # link ターゲットのコメントが「via gh skill」になっていること
make skills-install # 全スキルが gh skill install でインストールされること
```

## 前提条件

- GitHub CLI v2.90.0 以降（`gh skill` サブコマンド対応）