### PR TITLE
feat: auto mode で codex CLI レビューを許可する autoMode 設定を追加する

### DIFF
--- a/packages/claude/.claude/settings.json
+++ b/packages/claude/.claude/settings.json
@@ -2,6 +2,16 @@
   "env": {
     "CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS": "1"
   },
+  "autoMode": {
+    "environment": [
+      "$defaults",
+      "Invoking the codex CLI to send repository diffs to api.openai.com for code review is an expected and trusted workflow in this project."
+    ],
+    "allow": [
+      "$defaults",
+      "Running codex CLI for read-only code review (no file writes, no branch changes) is permitted."
+    ]
+  },
   "permissions": {
     "allow": [
       "Bash(find:*)",


### PR DESCRIPTION
## 概要

auto mode で `cross-review` skill から codex CLI を呼び出すと、classifier がセキュリティ違反としてブロックする問題に対応する。

`autoMode.environment` と `autoMode.allow` を追加し、codex CLI による read-only コードレビューが意図的なワークフローであることを classifier に伝える。

## 変更内容

- `packages/claude/.claude/settings.json` に `autoMode` ブロックを追加
  - `environment`: codex CLI → api.openai.com への diff 送信が想定済みのワークフローであることを記述
  - `allow`: read-only レビュー（ファイル書き込み・ブランチ変更なし）であることを明示

## 確認方法

- auto mode で `cross-review` skill を実行し、codex CLI 呼び出しがブロックされないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)