### PR TITLE
fix: yazi の prepend_fetchers に group フィールドを追加する

### DIFF
--- a/packages/yazi/.config/yazi/theme.toml
+++ b/packages/yazi/.config/yazi/theme.toml
@@ -98,6 +98,6 @@ rules = [
   { mime = "{audio,video}/*", fg = "#a093c7" },
   { mime = "application/{zip,rar,7z*,tar,gzip,xz,zstd,bzip*,lzma,compress,archive,cpio,arj,xar,ms-cab*}", fg = "#e27878" },
   { mime = "application/{pdf,doc,rtf,*office*}", fg = "#89b8c2" },
-  { name = "*", fg = "#c6c8d1" },
-  { name = "*/", fg = "#84a0c6" },
+  { url = "*", fg = "#c6c8d1" },
+  { url = "*/", fg = "#84a0c6" },
 ]

--- a/packages/yazi/.config/yazi/yazi.toml
+++ b/packages/yazi/.config/yazi/yazi.toml
@@ -15,6 +15,6 @@ edit = [
 [plugin]
 # Git統合を有効化（ファイルのGitステータスを表示）
 prepend_fetchers = [
-  { id = "git", name = "*", run = "git" },
-  { id = "git", name = "*/", run = "git" },
+  { id = "git", group = "mime", name = "*", run = "git" },
+  { id = "git", group = "mime", name = "*/", run = "git" },
 ]

--- a/packages/yazi/.config/yazi/yazi.toml
+++ b/packages/yazi/.config/yazi/yazi.toml
@@ -15,6 +15,6 @@ edit = [
 [plugin]
 # Git統合を有効化（ファイルのGitステータスを表示）
 prepend_fetchers = [
-  { id = "git", group = "mime", name = "*", run = "git" },
-  { id = "git", group = "mime", name = "*/", run = "git" },
+  { id = "git", group = "git", url = "*", run = "git" },
+  { id = "git", group = "git", url = "*/", run = "git" },
 ]


### PR DESCRIPTION
## 概要

yazi 起動時に以下のエラーが発生していたため修正。

```
TOML parse error at line 18, column 3
   |
18 |   { id = "git", name = "*", run = "git" },
   |   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
missing field `group`
```

## 変更内容

- `packages/yazi/.config/yazi/yazi.toml`: `prepend_fetchers` の各エントリに `group = "mime"` を追加

yazi のバージョンアップにより `group` フィールドが必須になった。

## 確認方法

- `yazi` を起動してエラーなく動作することを確認