### PR TITLE
chore: relax Codex sandbox mode

### DIFF
--- a/packages/codex/.codex/config.toml
+++ b/packages/codex/.codex/config.toml
@@ -2,7 +2,7 @@ model = "gpt-5.5"
 model_reasoning_effort = "medium"
 personality = "pragmatic"
 approval_policy = "on-request"
-sandbox_mode = "workspace-write"
+sandbox_mode = "danger-full-access"
 
 [features]
 runtime_metrics = true


### PR DESCRIPTION
## 目的

Codex CLI をメイン利用しやすくするため、Codex の sandbox mode を `workspace-write` から `danger-full-access` に変更します。

`approval_policy = "on-request"` は維持し、承認フローは残します。

## 変更内容

- `packages/codex/.codex/config.toml` の `sandbox_mode` を `danger-full-access` に変更

## 確認

- `codex --strict-config --version` で設定ファイルを読み込めることを確認