### PR TITLE
feat: OpenHands をローカル環境に導入する

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 Brewfile.lock.json
 .env
+config.local.toml

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,6 +49,7 @@ Use `make` targets as the standard workflow:
 - `make link`: `packages/` 配下を `$HOME` に stow でシンボリックリンク化。
 - `make unlink`: stow 管理のシンボリックリンクを削除。
 - `make setup-mcp`: Claude Code の MCP サーバーをセットアップ。
+- `make setup-openhands`: OpenHands を uv 経由でインストール（`uv` が前提）。
 
 Example: `make link` after adding a new file under `packages/zsh/`.
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: install update sync link unlink clean-legacy-claude-skills-stow setup-mcp skills-install promote-webfetch help
+.PHONY: install update sync link unlink clean-legacy-claude-skills-stow setup-openhands setup-mcp skills-install promote-webfetch help
 
 PACKAGES := zsh vim wezterm git npm starship yazi bat tig lazygit claude codex copilot worktrunk gh-dash mise pnpm atuin
 
@@ -47,6 +47,9 @@ skills-install: ## Install agent skills globally via gh skill
 	gh skill install anthropics/skills frontend-design --agent claude-code --scope user -f
 	gh skill install anthropics/skills skill-creator --agent claude-code --scope user -f
 	gh skill install vercel-labs/agent-browser agent-browser --agent claude-code --scope user -f
+
+setup-openhands: ## Install OpenHands via uv (uv must be installed)
+	uv tool install openhands --python 3.12
 
 setup-mcp: ## Setup MCP servers for Claude Code
 	-claude mcp add --scope user --transport stdio chrome-devtools -- npx chrome-devtools-mcp@latest

--- a/packages/mise/.config/mise/config.toml
+++ b/packages/mise/.config/mise/config.toml
@@ -6,5 +6,6 @@ python = "3.14.5"
 idiomatic_version_file_enable_tools = ["python", "node"]
 
 # API keys for local AI agents — set values in ~/.config/mise/config.local.toml (gitignored)
+# mise exports [env] entries as shell env vars; `openhands serve` inherits them automatically.
 # [env]
 # LLM_API_KEY = ""  # OpenHands: Anthropic / OpenAI / etc.

--- a/packages/mise/.config/mise/config.toml
+++ b/packages/mise/.config/mise/config.toml
@@ -4,3 +4,7 @@ python = "3.14.5"
 
 [settings]
 idiomatic_version_file_enable_tools = ["python", "node"]
+
+# API keys for local AI agents — set values in ~/.config/mise/config.local.toml (gitignored)
+# [env]
+# LLM_API_KEY = ""  # OpenHands: Anthropic / OpenAI / etc.


### PR DESCRIPTION
close #332

## 目的

Claude Code / Codex CLI の代替候補として OpenHands をローカル環境に導入できる状態を整える。

## 変更内容

| ファイル | 変更内容 |
|---|---|
| `Makefile` | `setup-openhands` target 追加（`uv tool install openhands --python 3.12`） |
| `packages/mise/.config/mise/config.toml` | `[env]` プレースホルダーコメント追加（`LLM_API_KEY` キー名のみ、値なし） |
| `.gitignore` | `config.local.toml` を追加（API キーの誤コミット防止） |
| `AGENTS.md` | コマンド一覧に `make setup-openhands` を追記 |

## ローカル検証手順

```sh
# Makefile の整合性確認
make help
# → setup-openhands が一覧に表示されることを確認

# .gitignore の確認
grep 'config.local.toml' .gitignore

# mise config.toml のプレースホルダー確認
grep -A3 '\[env\]' packages/mise/.config/mise/config.toml
```

## スコープ外

- OpenHands の実際のインストール・動作確認（`make setup-openhands` 実行と `openhands serve` 起動テスト）はローカル環境での手動確認が必要