### PR TITLE
fix: suppress codex unstable feature warning

### DIFF
--- a/packages/codex/.codex/config.toml
+++ b/packages/codex/.codex/config.toml
@@ -3,6 +3,7 @@ model_reasoning_effort = "medium"
 personality = "pragmatic"
 approval_policy = "on-request"
 sandbox_mode = "danger-full-access"
+suppress_unstable_features_warning = true
 
 [features]
 runtime_metrics = true


### PR DESCRIPTION
## 目的

Codex 起動時に `runtime_metrics` が under-development feature として警告表示されるため、機能は有効のまま警告だけを抑制します。

## 変更内容

- `packages/codex/.codex/config.toml` に `suppress_unstable_features_warning = true` を追加
- `runtime_metrics = true` は維持

## 確認

- `npx prettier@3 --check packages/codex/.codex/config.toml`
- `make help`