### PR TITLE
feat: Git fsck objects を有効化する

### DIFF
--- a/packages/git/.gitconfig
+++ b/packages/git/.gitconfig
@@ -15,6 +15,15 @@ autosquash = true
 [pull]
 ff = only
 
+[transfer]
+fsckObjects = true
+
+[fetch]
+fsckObjects = true
+
+[receive]
+fsckObjects = true
+
 [core]
 excludesfile = ~/.gitignore_global
 pager = delta

--- a/packages/git/.gitconfig
+++ b/packages/git/.gitconfig
@@ -15,7 +15,7 @@ autosquash = true
 [pull]
 ff = only
 
-# Verify received objects to harden fetch/receive at a small performance cost.
+# Verify received objects; fetch/receive are explicit even though transfer is a fallback.
 [transfer]
 fsckObjects = true
 

--- a/packages/git/.gitconfig
+++ b/packages/git/.gitconfig
@@ -15,6 +15,7 @@ autosquash = true
 [pull]
 ff = only
 
+# Verify received objects to harden fetch/receive at a small performance cost.
 [transfer]
 fsckObjects = true
 


### PR DESCRIPTION
close #307

## 目的

Git の受信オブジェクト整合性検証を有効化し、fetch / receive 時の git オブジェクト検証を強化します。

## 影響パッケージパス

- packages/git/.gitconfig

## 変更内容

- transfer.fsckObjects を true に設定
- fetch.fsckObjects を true に設定
- receive.fsckObjects を true に設定
- transfer が fallback になる点を踏まえ、fetch / receive も明示設定している意図をコメントで補足

## ローカル検証

- make help
- git config --global --get transfer.fsckObjects
- git config --global --get fetch.fsckObjects
- git config --global --get receive.fsckObjects
- acceptance-check: 4/4 通過
- cross-review: critical 0、warning 1（大規模 repo での性能影響。issue の目的に沿い現状維持）