### PR TITLE
feat: add git lfs

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -15,6 +15,7 @@ brew "stow"
 
 # --- Development CLI ---
 brew "git"
+brew "git-lfs"
 brew "git-delta"
 brew "tig"
 brew "lazygit"

--- a/packages/git/.gitconfig
+++ b/packages/git/.gitconfig
@@ -68,3 +68,8 @@ branch = main
 # GitAlias configuration
 [include]
     path = ~/.git-extensions/gitalias.txt
+[filter "lfs"]
+	required = true
+	clean = git-lfs clean -- %f
+	smudge = git-lfs smudge -- %f
+	process = git-lfs filter-process


### PR DESCRIPTION
## 概要
- Homebrew の管理対象に git-lfs を追加
- dotfiles の Git 設定に LFS filter 設定を追加

## 確認
- git diff --check -- Brewfile packages/git/.gitconfig
- make help
- brew bundle list --file=Brewfile
- git lfs version
- npx prettier@3 --check Brewfile packages/git/.gitconfig

## 補足
- brew bundle check --file=Brewfile は既存の未充足依存（libreoffice / awscli）により失敗