### PR TITLE
fix: update codex status line token items

### DIFF
--- a/packages/codex/.codex/config.toml
+++ b/packages/codex/.codex/config.toml
@@ -16,8 +16,8 @@ status_line = [
   "model-with-reasoning",
   "git-branch",
   "context-used",
-  "input-token-usage",
-  "output-token-usage",
+  "total-input-tokens",
+  "total-output-tokens",
   "five-hour-limit",
   "weekly-limit",
 ]


### PR DESCRIPTION
## 概要
- Codex の status_line に設定していた無効な token usage item 名を修正
- `input-token-usage` / `output-token-usage` を `total-input-tokens` / `total-output-tokens` に置換

## 確認
- `codex doctor --summary`
- `npx prettier@3 --check packages/codex/.codex/config.toml`