### PR TITLE
feat: add headroom wrap aliases and setup-headroom make target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: install update sync link unlink clean-legacy-claude-skills-stow setup-openhands setup-mcp skills-install promote-webfetch help
+.PHONY: install update sync link unlink clean-legacy-claude-skills-stow setup-openhands setup-mcp setup-headroom skills-install promote-webfetch help
 
 PACKAGES := zsh vim wezterm git npm starship yazi bat tig lazygit claude codex copilot worktrunk gh-dash mise pnpm atuin
 
@@ -50,6 +50,9 @@ skills-install: ## Install agent skills globally via gh skill
 
 setup-openhands: ## Install OpenHands via uv (uv must be installed)
 	uv tool install openhands --python 3.12
+
+setup-headroom: ## Install headroom-ai via pip (requires Python 3.10+)
+	pip install "headroom-ai[all]"
 
 setup-mcp: ## Setup MCP servers for Claude Code
 	-claude mcp add --scope user --transport stdio chrome-devtools -- npx chrome-devtools-mcp@latest

--- a/Makefile
+++ b/Makefile
@@ -51,8 +51,8 @@ skills-install: ## Install agent skills globally via gh skill
 setup-openhands: ## Install OpenHands via uv (uv must be installed)
 	uv tool install openhands --python 3.12
 
-setup-headroom: ## Install headroom-ai via pip (requires Python 3.10+)
-	pip install "headroom-ai[all]"
+setup-headroom: ## Install headroom-ai via pipx (requires Python 3.10+)
+	pipx install "headroom-ai[all]"
 
 setup-mcp: ## Setup MCP servers for Claude Code
 	-claude mcp add --scope user --transport stdio chrome-devtools -- npx chrome-devtools-mcp@latest

--- a/packages/zsh/.zshrc
+++ b/packages/zsh/.zshrc
@@ -37,6 +37,8 @@ alias cdr="cd \$(git rev-parse --show-toplevel 2>/dev/null || echo .)"
 alias c='clear'
 alias h='history'
 alias cl='claude'
+alias hcl='headroom wrap claude'
+alias hcx='headroom wrap codex'
 alias ports='lsof -i -P -n | grep LISTEN'
 alias wsc='wt switch --create --execute=claude'
 alias gwr='cd $(git worktree list | head -1 | awk "{print \$1}")'


### PR DESCRIPTION
## 概要

- [headroom](https://github.com/chopratejas/headroom) の wrap モード用エイリアスを `.zshrc` に追加
- インストール用の `make setup-headroom` ターゲットを `Makefile` に追加

## 変更内容

### `packages/zsh/.zshrc`

| エイリアス | コマンド | 用途 |
|---|---|---|
| `hcl` | `headroom wrap claude` | Claude をトークン圧縮付きで起動 |
| `hcx` | `headroom wrap codex` | Codex をトークン圧縮付きで起動 |

通常は既存の `cl` / `codex` を使い、圧縮したいセッションのみ `hcl` / `hcx` に切り替える運用。

### `Makefile`

```
make setup-headroom  # pip install "headroom-ai[all]" を実行
```

`setup-openhands` と同じ流儀で追加。初回セットアップ時に実行する。

## 動作確認

- `make help` に `setup-headroom` が表示されることを確認済み