### PR TITLE
fix: pin setup-headroom to Python 3.13

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,8 +51,8 @@ skills-install: ## Install agent skills globally via gh skill
 setup-openhands: ## Install OpenHands via uv (uv must be installed)
 	uv tool install openhands --python 3.12
 
-setup-headroom: ## Install headroom-ai via pipx (requires Python 3.10+)
-	pipx install "headroom-ai[all]"
+setup-headroom: ## Install headroom-ai via pipx (requires Python 3.10-3.13)
+	pipx install "headroom-ai[all]" --python python3.13
 
 setup-mcp: ## Setup MCP servers for Claude Code
 	-claude mcp add --scope user --transport stdio chrome-devtools -- npx chrome-devtools-mcp@latest


### PR DESCRIPTION
## 概要

- `make setup-headroom` が Python 3.14 環境でビルドエラーになる問題を修正

## 原因

`headroom-ai 0.23.0` が使用する PyO3 v0.22.6 は Python 3.13 までしか対応していない。
Python 3.14 がデフォルトの環境では pipx が 3.14 を選択し、Rust 拡張のビルドに失敗していた。

## 対応

`pipx install` に `--python python3.13` を追加して Python バージョンを固定。
`setup-openhands` が `--python 3.12` を指定しているのと同じパターン。

## 確認手順

```
make setup-headroom
```

> `installed package headroom-ai 0.23.0, installed using Python 3.13.13` と表示されればOK

🤖 Generated with [Claude Code](https://claude.com/claude-code)