### PR TITLE
feat: add Codex MCP setup target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: install update sync link unlink clean-legacy-claude-skills-stow setup-openhands setup-mcp setup-headroom skills-install promote-webfetch help
+.PHONY: install update sync link unlink clean-legacy-claude-skills-stow setup-openhands setup-mcp setup-claude-mcp setup-codex-mcp setup-headroom skills-install promote-webfetch help
 
 PACKAGES := zsh vim wezterm git npm starship yazi bat tig lazygit claude codex copilot worktrunk gh-dash mise pnpm atuin
 
@@ -54,8 +54,13 @@ setup-openhands: ## Install OpenHands via uv (uv must be installed)
 setup-headroom: ## Install headroom-ai via pipx (requires Python 3.10-3.13)
 	pipx install "headroom-ai[all]" --python python3.13
 
-setup-mcp: ## Setup MCP servers for Claude Code
+setup-mcp: setup-claude-mcp setup-codex-mcp ## Setup MCP servers for AI coding agents
+
+setup-claude-mcp: ## Setup MCP servers for Claude Code
 	-claude mcp add --scope user --transport stdio chrome-devtools -- npx chrome-devtools-mcp@latest
+
+setup-codex-mcp: ## Setup MCP servers for Codex
+	-codex mcp add headroom -- headroom mcp serve
 
 promote-webfetch: ## Promote WebFetch domains from history to permissions.allow
 	./scripts/promote-webfetch.sh


### PR DESCRIPTION
## 概要
- `setup-mcp` を Claude Code / Codex の両方をセットアップする親ターゲットに変更
- Claude Code 用の `setup-claude-mcp` と Codex 用の `setup-codex-mcp` を追加
- Codex 用 MCP として Headroom MCP server を登録するコマンドを追加

## 確認
- `make help`
- `make -n setup-mcp`