### PR TITLE
chore: Python CLI ツールのインストール定義を分離

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,8 @@
-.PHONY: install update sync link unlink clean-legacy-claude-skills-stow setup-openhands setup-mcp setup-claude-mcp setup-codex-mcp setup-headroom skills-install promote-webfetch help
+.PHONY: install update sync link unlink clean-legacy-claude-skills-stow setup-python-tools setup-uv-tools setup-pipx-tools setup-openhands setup-mcp setup-claude-mcp setup-codex-mcp setup-headroom skills-install promote-webfetch help
 
 PACKAGES := zsh vim wezterm git npm starship yazi bat tig lazygit claude codex copilot worktrunk gh-dash mise pnpm atuin
+UV_TOOLS_FILE := packages/python-tools/.default-uv-tools
+PIPX_TOOLS_FILE := packages/python-tools/.default-pipx-tools
 
 help: ## Show this help
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-15s\033[0m %s\n", $$1, $$2}'
@@ -48,11 +50,23 @@ skills-install: ## Install agent skills globally via gh skill
 	gh skill install anthropics/skills skill-creator --agent claude-code --scope user -f
 	gh skill install vercel-labs/agent-browser agent-browser --agent claude-code --scope user -f
 
-setup-openhands: ## Install OpenHands via uv (uv must be installed)
-	uv tool install openhands --python 3.12
+setup-python-tools: setup-uv-tools setup-pipx-tools ## Install Python CLI tools
 
-setup-headroom: ## Install headroom-ai via pipx (requires Python 3.10-3.13)
-	pipx install "headroom-ai[all]" --python python3.13
+setup-uv-tools: ## Install Python CLI tools via uv
+	@while read -r package python; do \
+		case "$$package" in ""|\#*) continue;; esac; \
+		uv tool install "$$package" --python "$$python"; \
+	done < "$(UV_TOOLS_FILE)"
+
+setup-pipx-tools: ## Install Python CLI tools via pipx
+	@while read -r package python; do \
+		case "$$package" in ""|\#*) continue;; esac; \
+		pipx install "$$package" --python "$$python"; \
+	done < "$(PIPX_TOOLS_FILE)"
+
+setup-openhands: setup-uv-tools ## Install OpenHands via uv (uv must be installed)
+
+setup-headroom: setup-pipx-tools ## Install headroom-ai via pipx (requires Python 3.10-3.13)
 
 setup-mcp: setup-claude-mcp setup-codex-mcp ## Setup MCP servers for AI coding agents
 

--- a/packages/python-tools/.default-pipx-tools
+++ b/packages/python-tools/.default-pipx-tools
@@ -1,0 +1,2 @@
+# package python
+headroom-ai[all] python3.13

--- a/packages/python-tools/.default-uv-tools
+++ b/packages/python-tools/.default-uv-tools
@@ -1,0 +1,2 @@
+# package python
+openhands 3.12


### PR DESCRIPTION
## 概要
- OpenHands / Headroom のインストール定義を Makefile 直書きから一覧ファイルへ分離
- uv 管理ツールと pipx 管理ツールをそれぞれ別ファイルで管理
- 既存の setup-openhands / setup-headroom ターゲットは互換性のため残し、一覧ベースのターゲットへ委譲

## 変更箇所
- Makefile
- packages/python-tools/.default-uv-tools
- packages/python-tools/.default-pipx-tools

## 確認
- make help
- make -n setup-python-tools
- make -n setup-uv-tools
- make -n setup-pipx-tools
- make -n setup-openhands
- make -n setup-headroom