### PR TITLE
fix: simplify homebrew install setup

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -1,7 +1,6 @@
 # --- Tap repositories ---
 tap "homebrew/bundle"
 tap "charmbracelet/tap"
-tap "azure/functions"
 tap "k1LoW/tap"
 tap "steipete/tap"
 
@@ -51,8 +50,6 @@ cask "orbstack"
 brew "tfenv"
 brew "tflint"
 brew "awscli"
-brew "azure-cli"
-brew "azure-functions-core-tools@4"
 cask "gcloud-cli"
 
 # --- Development Apps ---

--- a/install.sh
+++ b/install.sh
@@ -9,11 +9,12 @@ if [ "$kernelName" != 'Darwin' ]; then
   exit 1
 fi
 
-printf '\n-- install Homebrew and formulaes --\n'
+printf '\n-- install Homebrew and formulae --\n'
 if ! command -v brew &> /dev/null; then
   curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh | /bin/bash
 fi
-brew bundle -v --cleanup
+
+brew bundle install --cleanup --force-cleanup --file=Brewfile
 
 printf '\n-- create symbolic links with stow --\n'
 make link


### PR DESCRIPTION
## Summary
- remove obsolete azure/functions tap from Brewfile
- remove Azure CLI and Azure Functions Core Tools from managed Homebrew packages
- keep brew bundle cleanup during install by passing --force-cleanup explicitly

## Verification
- bash -n install.sh
- make help
- brew bundle install --file=Brewfile