### PR TITLE
chore: remove redundant setup-openhands and setup-headroom targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: install update sync link unlink clean-legacy-claude-skills-stow setup-python-tools setup-uv-tools setup-pipx-tools setup-openhands setup-mcp setup-claude-mcp setup-codex-mcp setup-headroom skills-install promote-webfetch help
+.PHONY: install update sync link unlink clean-legacy-claude-skills-stow setup-python-tools setup-uv-tools setup-pipx-tools setup-mcp setup-claude-mcp setup-codex-mcp skills-install promote-webfetch help
 
 PACKAGES := zsh vim wezterm git npm starship yazi bat tig lazygit claude codex copilot worktrunk gh-dash mise pnpm atuin
 UV_TOOLS_FILE := packages/python-tools/.default-uv-tools
@@ -63,10 +63,6 @@ setup-pipx-tools: ## Install Python CLI tools via pipx
 		case "$$package" in ""|\#*) continue;; esac; \
 		pipx install "$$package" --python "$$python"; \
 	done < "$(PIPX_TOOLS_FILE)"
-
-setup-openhands: setup-uv-tools ## Install OpenHands via uv (uv must be installed)
-
-setup-headroom: setup-pipx-tools ## Install headroom-ai via pipx (requires Python 3.10-3.13)
 
 setup-mcp: setup-claude-mcp setup-codex-mcp ## Setup MCP servers for AI coding agents
 


### PR DESCRIPTION
## 概要

`setup-openhands` と `setup-headroom` の Makefile ターゲットを削除する。

- `setup-openhands: setup-uv-tools` — `setup-uv-tools` の単なるエイリアスで固有の処理なし
- `setup-headroom: setup-pipx-tools` — `setup-pipx-tools` の単なるエイリアスで固有の処理なし

実際のインストール設定は `UV_TOOLS_FILE` / `PIPX_TOOLS_FILE` で管理されており、`setup-python-tools` で両方カバーされるため不要。

## 確認手順

- `make help` でターゲット一覧が正しく表示されること
- `make setup-python-tools` でツールがインストールできること