### PR TITLE
chore: remove headroom settings

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: install update sync link unlink clean-legacy-claude-skills-stow setup-python-tools setup-uv-tools setup-pipx-tools setup-mcp setup-claude-mcp setup-codex-mcp skills-install promote-webfetch help
+.PHONY: install update sync link unlink clean-legacy-claude-skills-stow setup-python-tools setup-uv-tools setup-pipx-tools setup-mcp setup-claude-mcp skills-install promote-webfetch help
 
 PACKAGES := zsh vim wezterm git npm starship yazi bat tig lazygit claude codex copilot worktrunk gh-dash mise pnpm atuin
 UV_TOOLS_FILE := packages/python-tools/.default-uv-tools
@@ -64,13 +64,10 @@ setup-pipx-tools: ## Install Python CLI tools via pipx
 		pipx install "$$package" --python "$$python"; \
 	done < "$(PIPX_TOOLS_FILE)"
 
-setup-mcp: setup-claude-mcp setup-codex-mcp ## Setup MCP servers for AI coding agents
+setup-mcp: setup-claude-mcp ## Setup MCP servers for AI coding agents
 
 setup-claude-mcp: ## Setup MCP servers for Claude Code
 	-claude mcp add --scope user --transport stdio chrome-devtools -- npx chrome-devtools-mcp@latest
-
-setup-codex-mcp: ## Setup MCP servers for Codex
-	-codex mcp add headroom -- headroom mcp serve
 
 promote-webfetch: ## Promote WebFetch domains from history to permissions.allow
 	./scripts/promote-webfetch.sh

--- a/packages/python-tools/.default-pipx-tools
+++ b/packages/python-tools/.default-pipx-tools
@@ -1,2 +1,1 @@
 # package python
-headroom-ai[all] python3.13

--- a/packages/zsh/.zshrc
+++ b/packages/zsh/.zshrc
@@ -37,8 +37,6 @@ alias cdr="cd \$(git rev-parse --show-toplevel 2>/dev/null || echo .)"
 alias c='clear'
 alias h='history'
 alias cl='claude'
-alias hcl='headroom wrap claude --no-serena'
-alias hcx='headroom wrap codex --no-serena'
 alias ports='lsof -i -P -n | grep LISTEN'
 alias wsc='wt switch --create --execute=claude'
 alias gwr='cd $(git worktree list | head -1 | awk "{print \$1}")'


### PR DESCRIPTION
## 概要
- headroom の Codex MCP 登録を Makefile から削除
- headroom wrap 用の zsh alias を削除
- pipx 管理対象から headroom-ai を削除

## 確認
- rg --hidden -n "headroom|mcp__headroom|headroom_" . --glob '!.git/**'
- make help
- npx prettier@3 --check .