### PR TITLE
fix: Codex の MCP セットアップを追加

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: install update sync link unlink clean-legacy-claude-skills-stow setup-python-tools setup-uv-tools setup-pipx-tools setup-mcp setup-claude-mcp skills-install promote-webfetch help
+.PHONY: install update sync link unlink clean-legacy-claude-skills-stow setup-python-tools setup-uv-tools setup-pipx-tools setup-mcp setup-claude-mcp setup-codex-mcp skills-install promote-webfetch help
 
 PACKAGES := zsh vim wezterm git npm starship yazi bat tig lazygit claude codex copilot worktrunk gh-dash mise pnpm atuin
 UV_TOOLS_FILE := packages/python-tools/.default-uv-tools
@@ -64,10 +64,13 @@ setup-pipx-tools: ## Install Python CLI tools via pipx
 		pipx install "$$package" --python "$$python"; \
 	done < "$(PIPX_TOOLS_FILE)"
 
-setup-mcp: setup-claude-mcp ## Setup MCP servers for AI coding agents
+setup-mcp: setup-claude-mcp setup-codex-mcp ## Setup MCP servers for AI coding agents
 
 setup-claude-mcp: ## Setup MCP servers for Claude Code
 	-claude mcp add --scope user --transport stdio chrome-devtools -- npx chrome-devtools-mcp@latest
+
+setup-codex-mcp: ## Setup MCP servers for Codex
+	-codex mcp add chrome-devtools -- npx chrome-devtools-mcp@latest
 
 promote-webfetch: ## Promote WebFetch domains from history to permissions.allow
 	./scripts/promote-webfetch.sh


### PR DESCRIPTION
## 概要
- `make setup-mcp` で Claude Code と Codex の MCP セットアップを両方実行するように変更
- Codex 用の `setup-codex-mcp` ターゲットを追加
- Claude Code と同じ `chrome-devtools` MCP サーバーを `npx chrome-devtools-mcp@latest` で登録

## 確認
- `make help`
- `make -n setup-mcp`
- `git diff --check -- Makefile`