### PR TITLE
fix: update python tools setup docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,7 +49,7 @@ Use `make` targets as the standard workflow:
 - `make link`: `packages/` 配下を `$HOME` に stow でシンボリックリンク化。
 - `make unlink`: stow 管理のシンボリックリンクを削除。
 - `make setup-mcp`: Claude Code の MCP サーバーをセットアップ。
-- `make setup-openhands`: OpenHands を uv 経由でインストール（`uv` が前提）。
+- `make setup-python-tools`: OpenHands などの Python CLI ツールを `uv` / `pipx` 経由でインストール。
 
 Example: `make link` after adding a new file under `packages/zsh/`.
 

--- a/README.md
+++ b/README.md
@@ -18,14 +18,15 @@ make install
 
 ## 主要コマンド
 
-| Command        | 用途                                                      |
-| -------------- | --------------------------------------------------------- |
-| `make help`    | 利用可能なタスク一覧を表示                                |
-| `make install` | 初回セットアップ                                          |
-| `make link`    | `packages/` 配下を `$HOME` に stow でシンボリックリンク化 |
-| `make unlink`  | stow 管理のシンボリックリンクを削除                       |
-| `make update`  | `Brewfile` から Homebrew パッケージを更新                 |
-| `make sync`    | 現在の Homebrew 状態を `Brewfile` に書き戻し              |
+| Command                   | 用途                                                      |
+| ------------------------- | --------------------------------------------------------- |
+| `make help`               | 利用可能なタスク一覧を表示                                |
+| `make install`            | 初回セットアップ                                          |
+| `make link`               | `packages/` 配下を `$HOME` に stow でシンボリックリンク化 |
+| `make unlink`             | stow 管理のシンボリックリンクを削除                       |
+| `make update`             | `Brewfile` から Homebrew パッケージを更新                 |
+| `make sync`               | 現在の Homebrew 状態を `Brewfile` に書き戻し              |
+| `make setup-python-tools` | OpenHands などの Python CLI ツールをインストール          |
 
 ## 詳細
 


### PR DESCRIPTION
## 目的

存在しない `make setup-openhands` への参照を、実在する Python CLI ツール導入用 target に修正します。

## 変更内容

- `AGENTS.md` の `make setup-openhands` を `make setup-python-tools` に置き換え
- `README.md` の主要コマンド表に `make setup-python-tools` を追記

## 確認

- `npx prettier@3 --check AGENTS.md README.md`
- `make help`