### PR TITLE
feat: add codex alias

### DIFF
--- a/packages/zsh/.zshrc
+++ b/packages/zsh/.zshrc
@@ -37,6 +37,7 @@ alias cdr="cd \$(git rev-parse --show-toplevel 2>/dev/null || echo .)"
 alias c='clear'
 alias h='history'
 alias cl='claude'
+alias cx='codex'
 alias ports='lsof -i -P -n | grep LISTEN'
 alias wsc='wt switch --create --execute=claude'
 alias gwr='cd $(git worktree list | head -1 | awk "{print \$1}")'


### PR DESCRIPTION
## 概要
- zsh の alias に codex 用の短縮コマンド cx を追加しました。

## 影響範囲
- packages/zsh/.zshrc

## 確認
- zsh -n packages/zsh/.zshrc