### PR TITLE
[codex] remove miro from Brewfile

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -83,7 +83,6 @@ cask "microsoft-edge"
 cask "slack"
 cask "discord"
 cask "zoom"
-cask "miro"
 cask "figma"
 
 # --- AI Tools ---


### PR DESCRIPTION
## 概要

- `Brewfile` から Miro の cask を削除しました。

## 影響

- `make install` や `make update` で Homebrew Bundle を実行しても Miro がインストール対象に含まれなくなります。

## 確認

- `ruby -c Brewfile`
- `jq empty Brewfile.lock.json`
- `make help`

## 補足

- `Brewfile.lock.json` は `.gitignore` で Git 管理外のため、PR には含めていません。
- 既存の未コミット変更 `packages/claude/.claude/settings.json` と `packages/codex/.codex/config.toml` は対象外として触っていません。