### PR TITLE
[codex] HOMEBREW_CASK_OPTS の常時設定を削除する

### DIFF
--- a/packages/zsh/.zshrc
+++ b/packages/zsh/.zshrc
@@ -1,7 +1,6 @@
 eval "$(/opt/homebrew/bin/brew shellenv)"
 export HOMEBREW_NO_ANALYTICS=1
 export HOMEBREW_NO_INSECURE_REDIRECT=1
-export HOMEBREW_CASK_OPTS="--require-sha"
 export PATH="$HOME/.local/bin:$PATH"
 
 fpath+=("/opt/homebrew/share/zsh/site-functions")


### PR DESCRIPTION
## 目的

`HOMEBREW_CASK_OPTS="--require-sha"` の常時設定を削除し、`make update` / `brew bundle` が checksum を持たない公式 cask で失敗しやすくなる問題を避ける。

## 変更内容

- `packages/zsh/.zshrc` から `HOMEBREW_CASK_OPTS="--require-sha"` の export を削除
- `HOMEBREW_NO_ANALYTICS` と `HOMEBREW_NO_INSECURE_REDIRECT` は維持

## 背景

Homebrew Cask には `sha256 :no_check` が公式に使われるケースがあり、`--require-sha` を常時有効にすると `brew bundle` の日常更新で失敗する cask が出る。セキュリティ強化の意図はあるが、dotfiles の通常運用では摩擦が大きいためデフォルトから外す。

## 影響パッケージパス

- `packages/zsh/.zshrc`

## ローカル検証

```sh
make help
npx prettier@3 --check packages/zsh/.zshrc Makefile
```

補足: commit hook 実行時に `lefthook` が PATH にない旨の表示が出たが、commit は成功している。