### PR TITLE
feat: manage aze-cli with mise npm backend

### DIFF
--- a/packages/mise/.config/mise/config.toml
+++ b/packages/mise/.config/mise/config.toml
@@ -1,6 +1,7 @@
 [tools]
 node = "24.16.0"
 python = "3.14.5"
+"npm:aze-cli" = "0.5.0"
 
 [settings]
 idiomatic_version_file_enable_tools = ["python", "node"]


### PR DESCRIPTION
## 概要

- mise の tools に `npm:aze-cli` を追加
- `aze-cli` を `0.5.0` に固定し、Node 24.16.0 前提の環境で再現できるようにした

## 確認

- `npx prettier@3 --check packages/mise/.config/mise/config.toml`
- `mise ls --current npm:aze-cli`