### PR TITLE
chore: update aze to 0.5.1

### DIFF
--- a/packages/mise/.config/mise/config.toml
+++ b/packages/mise/.config/mise/config.toml
@@ -1,7 +1,7 @@
 [tools]
 node = "24.16.0"
 python = "3.14.5"
-"npm:aze-cli" = "0.5.0"
+"npm:aze-cli" = "0.5.1"
 
 [settings]
 idiomatic_version_file_enable_tools = ["python", "node"]


### PR DESCRIPTION
## 概要
- mise で管理している npm:aze-cli を 0.5.0 から 0.5.1 に更新

## 確認
- npm view aze-cli@0.5.1 version dist.tarball
- npx prettier@3 --check .
- make help