### PR TITLE
fix: disable atuin enter accept

### DIFF
--- a/packages/atuin/.config/atuin/config.toml
+++ b/packages/atuin/.config/atuin/config.toml
@@ -6,7 +6,7 @@ filter_mode = "global"
 workspaces = true
 
 style = "compact"
-enter_accept = true
+enter_accept = false
 show_preview = true
 
 secrets_filter = true


### PR DESCRIPTION
## 目的

Atuin の履歴検索で選択したコマンドを即実行せず、コマンドライン上で編集できるようにする。

## 変更内容

- `packages/atuin/.config/atuin/config.toml` の `enter_accept` を `false` に変更

## 確認

- `atuin config get enter_accept --verbose` で `Resolved: false` を確認
- `npx prettier@3 --check packages/atuin/.config/atuin/config.toml` を実行