### PR TITLE
feat: manage shirube with mise

### DIFF
--- a/packages/mise/.config/mise/config.toml
+++ b/packages/mise/.config/mise/config.toml
@@ -2,6 +2,7 @@
 node = "24.16.0"
 python = "3.14.5"
 "npm:aze-cli" = "0.5.1"
+"npm:shirube" = "1.1.0"
 
 [settings]
 idiomatic_version_file_enable_tools = ["python", "node"]


### PR DESCRIPTION
## 概要
- mise の npm tool として shirube を追加
- npm の min release age 設定で現時点で導入可能な shirube 1.1.0 に固定

## 確認
- mise install
- zsh -lic 'command -v shirube && shirube --version'
- make help