### PR TITLE
chore: mise 管理の npm ツールを更新

### DIFF
--- a/packages/mise/.config/mise/config.toml
+++ b/packages/mise/.config/mise/config.toml
@@ -1,8 +1,8 @@
 [tools]
 node = "24.16.0"
 python = "3.14.5"
-"npm:aze-cli" = "0.5.1"
-"npm:shirube" = "1.1.0"
+"npm:aze-cli" = "0.5.3"
+"npm:shirube" = "1.2.2"
 
 [settings]
 idiomatic_version_file_enable_tools = ["python", "node"]


### PR DESCRIPTION
## 概要
- mise 管理の npm:aze-cli を 0.5.3 に更新
- mise 管理の npm:shirube を 1.2.2 に更新

## 確認
- npm view aze-cli version dist-tags --json
- npm view shirube version dist-tags --json
- NPM_CONFIG_MIN_RELEASE_AGE=0 mise install npm:aze-cli@0.5.3 npm:shirube@1.2.2
- mise list --current
- mise exec -- aze --version
- mise exec -- shirube --version
- npx prettier@3 --check packages/mise/.config/mise/config.toml
- git diff --check -- packages/mise/.config/mise/config.toml

## 補足
- ローカル環境では NPM_CONFIG_MIN_RELEASE_AGE=7 により公開から7日未満の npm パッケージが除外されるため、インストール検証時のみ 0 に上書きしました。