### PR TITLE
feat: cwt agent worktree launcher を追加

### DIFF
--- a/packages/worktrunk/.config/worktrunk/config.toml
+++ b/packages/worktrunk/.config/worktrunk/config.toml
@@ -6,21 +6,58 @@ command = "MAX_THINKING_TOKENS=0 claude -p --model=haiku --tools='' --disable-sl
 
 [[pre-start]]
 symlink-env = """
-main_dir="{{ primary_worktree_path }}"
-find "$main_dir" -maxdepth 5 -name '.env' -o -name '.env.local' | while read -r src; do
+main_dir={{ primary_worktree_path }}
+find "$main_dir" -maxdepth 5 \\( -path "$main_dir/.git" -o -path "$main_dir/.worktrees" \\) -prune -o \\( -name '.env' -o -name '.env.local' -o -name '.env.*.local' \\) -type f -print | while read -r src; do
   rel="${src#$main_dir/}"
-  dir="$(dirname "$rel")"
-  [ "$dir" != "." ] && mkdir -p "$dir"
-  ln -sf "$src" "$rel"
+  if ! git -C "$main_dir" ls-files --error-unmatch "$rel" >/dev/null 2>&1; then
+    dir="$(dirname "$rel")"
+    [ "$dir" != "." ] && mkdir -p "$dir"
+    if [ ! -e "$rel" ] && [ ! -L "$rel" ]; then
+      ln -s "$src" "$rel"
+    fi
+  fi
 done
 """
 
 [[pre-start]]
 claude-settings = """
-main_dir="{{ primary_worktree_path }}"
+main_dir={{ primary_worktree_path }}
 if [ -f "$main_dir/.claude/settings.local.json" ]; then
   mkdir -p .claude
   rm -f .claude/settings.local.json
   ln -s "$main_dir/.claude/settings.local.json" .claude/settings.local.json
+fi
+"""
+
+[[pre-start]]
+codex-settings = """
+main_dir={{ primary_worktree_path }}
+
+if [ -f "$main_dir/.codex/config.toml" ] && ! git -C "$main_dir" ls-files --error-unmatch ".codex/config.toml" >/dev/null 2>&1; then
+  mkdir -p .codex
+  if [ ! -e .codex/config.toml ] && [ ! -L .codex/config.toml ]; then
+    ln -s "$main_dir/.codex/config.toml" .codex/config.toml
+  fi
+fi
+
+if [ -d "$main_dir/.codex/rules" ]; then
+  tracked_codex_rules="$(git -C "$main_dir" ls-files -- ".codex/rules")"
+  if [ -z "$tracked_codex_rules" ]; then
+    mkdir -p .codex
+    if [ ! -e .codex/rules ] && [ ! -L .codex/rules ]; then
+      ln -s "$main_dir/.codex/rules" .codex/rules
+    fi
+  else
+    find "$main_dir/.codex/rules" -type f | while read -r src; do
+      rel="${src#$main_dir/}"
+      if ! git -C "$main_dir" ls-files --error-unmatch "$rel" >/dev/null 2>&1; then
+        dest="$rel"
+        if [ ! -e "$dest" ] && [ ! -L "$dest" ]; then
+          mkdir -p "$(dirname "$dest")"
+          ln -s "$src" "$dest"
+        fi
+      fi
+    done
+  fi
 fi
 """

--- a/packages/zsh/.zshrc
+++ b/packages/zsh/.zshrc
@@ -41,6 +41,198 @@ alias ports='lsof -i -P -n | grep LISTEN'
 alias wsc='wt switch --create --execute=claude'
 alias gwr='cd $(git worktree list | head -1 | awk "{print \$1}")'
 
+# cwt: coding worktree - AI にブランチ名を決めさせて worktree で agent を起動
+function cwt() {
+  local agent="codex"
+  local -a task_parts
+
+  while [ $# -gt 0 ]; do
+    case "$1" in
+      --codex)
+        agent="codex"
+        shift
+        ;;
+      --claude)
+        agent="claude"
+        shift
+        ;;
+      -h | --help)
+        echo "Usage: cwt [--codex|--claude] <issue-url|issue-number|task text>"
+        return 0
+        ;;
+      --)
+        shift
+        task_parts+=("$@")
+        break
+        ;;
+      --*)
+        echo "unknown option: $1"
+        return 1
+        ;;
+      *)
+        task_parts+=("$1")
+        shift
+        ;;
+    esac
+  done
+
+  if [ ${#task_parts[@]} -eq 0 ]; then
+    echo "Usage: cwt [--codex|--claude] <issue-url|issue-number|task text>"
+    return 1
+  fi
+
+  if ! command -v "$agent" >/dev/null 2>&1; then
+    echo "$agent command not found"
+    return 1
+  fi
+  if ! command -v wt >/dev/null 2>&1; then
+    echo "wt command not found"
+    return 1
+  fi
+
+  local repo_root
+  repo_root=$(git rev-parse --show-toplevel 2>/dev/null) || {
+    echo "not inside a git repository"
+    return 1
+  }
+  repo_root="${repo_root:A}"
+
+  local primary_worktree
+  primary_worktree=$(git -C "$repo_root" worktree list --porcelain | sed -n '1s/^worktree //p')
+  primary_worktree="${primary_worktree:A}"
+  if [ "$repo_root" != "$primary_worktree" ]; then
+    echo "cwt must be run from the primary worktree"
+    echo "current: $repo_root"
+    echo "primary: $primary_worktree"
+    return 1
+  fi
+
+  local task issue_ref issue_context agent_prompt
+  task="${(j: :)task_parts}"
+  issue_context=""
+
+  if [[ "$task" == <-> ]]; then
+    issue_ref="$task"
+  elif [[ "$task" == \#<-> ]]; then
+    issue_ref="${task#\#}"
+  elif [[ "$task" =~ '^https://github.com/([^/]+)/([^/]+)/issues/([0-9]+)([/?#].*)?$' ]]; then
+    if ! command -v gh >/dev/null 2>&1; then
+      echo "gh command not found"
+      return 1
+    fi
+    local issue_repo current_repo
+    issue_repo="${match[1]}/${match[2]}"
+    current_repo=$(gh repo view --json nameWithOwner --jq .nameWithOwner 2>/dev/null)
+    if [ -n "$current_repo" ] && [ "$issue_repo" != "$current_repo" ]; then
+      echo "issue belongs to another repository: $issue_repo"
+      echo "current repository: $current_repo"
+      return 1
+    fi
+    issue_ref="$task"
+  fi
+
+  if [ -n "$issue_ref" ]; then
+    if ! command -v gh >/dev/null 2>&1; then
+      echo "gh command not found"
+      return 1
+    fi
+    issue_context=$(gh issue view "$issue_ref" --json title,body,url --template '{{printf "URL: %s\nTitle: %s\nBody:\n%s\n" .url .title .body}}') || return 1
+    agent_prompt="Work on this issue:
+
+$issue_context"
+  else
+    agent_prompt="$task"
+  fi
+
+  local naming_source naming_prompt branch
+  naming_source="${issue_context:-$task}"
+  naming_prompt="Generate exactly one git branch name for this task.
+
+Rules:
+- Output only the branch name.
+- Use one of these prefixes: feat/, fix/, chore/, docs/, refactor/.
+- Use concise English kebab-case after the prefix.
+- Prefer 3 to 6 words after the prefix.
+- Do not wrap the answer in quotes or backticks.
+
+Task:
+$naming_source"
+
+  echo "ブランチ名を決定中..."
+  if command -v codex >/dev/null 2>&1; then
+    local branch_file
+    local -a codex_namer_args
+    branch_file=$(mktemp "${TMPDIR:-/tmp}/cwt-branch.XXXXXX") || return 1
+    codex_namer_args=(exec --ephemeral --sandbox read-only --skip-git-repo-check --ignore-rules)
+    if [ -n "$CWT_NAMER_MODEL" ]; then
+      codex_namer_args+=(-m "$CWT_NAMER_MODEL")
+    fi
+    command codex "${codex_namer_args[@]}" -o "$branch_file" "$naming_prompt" >/dev/null || {
+      rm -f "$branch_file"
+      return 1
+    }
+    branch=$(tail -n 1 "$branch_file" | tr -d '`' | xargs)
+    rm -f "$branch_file"
+  elif command -v claude >/dev/null 2>&1; then
+    branch=$(command claude -p "$naming_prompt" | tail -n 1 | tr -d '`' | xargs)
+  else
+    echo "codex or claude command not found"
+    return 1
+  fi
+
+  if [ -z "$branch" ]; then
+    echo "ブランチ名の決定に失敗しました"
+    return 1
+  fi
+
+  branch="${branch#refs/heads/}"
+  if [[ ! "$branch" =~ '^(feat|fix|chore|docs|refactor)/[a-z0-9]+(-[a-z0-9]+)*$' ]]; then
+    echo "invalid branch name format: $branch"
+    echo "expected: feat|fix|chore|docs|refactor followed by english kebab-case"
+    return 1
+  fi
+  if ! git -C "$repo_root" check-ref-format --branch "$branch" >/dev/null 2>&1; then
+    echo "invalid branch name: $branch"
+    return 1
+  fi
+  if git -C "$repo_root" show-ref --verify --quiet "refs/heads/$branch"; then
+    echo "branch already exists: $branch"
+    return 1
+  fi
+
+  echo "branch: $branch"
+  local prompt_file launcher_file
+  prompt_file=$(mktemp "${TMPDIR:-/tmp}/cwt-prompt.XXXXXX") || return 1
+  launcher_file=$(mktemp "${TMPDIR:-/tmp}/cwt-launcher.XXXXXX") || {
+    rm -f "$prompt_file"
+    return 1
+  }
+  print -r -- "$agent_prompt" >"$prompt_file" || {
+    rm -f "$prompt_file" "$launcher_file"
+    return 1
+  }
+  cat >"$launcher_file" <<'EOF'
+#!/bin/sh
+set -eu
+agent=$1
+prompt_file=$2
+prompt=$(cat "$prompt_file")
+rm -f "$prompt_file" "$0"
+exec "$agent" "$prompt"
+EOF
+  chmod +x "$launcher_file" || {
+    rm -f "$prompt_file" "$launcher_file"
+    return 1
+  }
+
+  command wt switch --create "$branch" --base=@ --execute="$launcher_file" -- "$agent" "$prompt_file"
+  local cwt_status=$?
+  if [ "$cwt_status" -ne 0 ]; then
+    rm -f "$prompt_file" "$launcher_file"
+  fi
+  return "$cwt_status"
+}
+
 # starship
 eval "$(starship init zsh)"
 


### PR DESCRIPTION
## 概要

Codex をデフォルト、Claude Code を option として使える `cwt` shell function を追加します。worktree の作成・移動・agent 起動は既存運用に合わせて `wt switch --create --execute` に委譲します。

## 変更内容

- `cwt [--codex|--claude] <issue-url|issue-number|task text>` を追加
- issue URL / issue number の場合は `gh issue view` で issue 情報を取得
- Codex / Claude でブランチ名を AI 生成し、`feat/`, `fix/`, `chore/`, `docs/`, `refactor/` + kebab-case の allowlist で検証
- `wt switch --create <branch> --base=@ --execute=<launcher>` で現在の primary HEAD から worktree を作成し、agent を起動
- worktrunk の template 展開を避けるため、agent prompt は一時ファイル経由で launcher に渡す
- primary worktree 以外からの二重 worktree 作成を拒否
- worktrunk `pre-start` hook で untracked / ignored の `.env`, `.env.local`, `.env.*.local`, `.claude/settings.local.json`, `.codex/config.toml`, `.codex/rules` を必要に応じて symlink

## 検証

- `zsh -n packages/zsh/.zshrc`
- `zsh -c 'source packages/zsh/.zshrc; cwt --help'`
- `npx prettier@3 --check packages/zsh/.zshrc packages/worktrunk/.config/worktrunk/config.toml`
- `git diff --check -- packages/zsh/.zshrc packages/worktrunk/.config/worktrunk/config.toml`
- `wt --config packages/worktrunk/.config/worktrunk/config.toml config show`
- `wt --config packages/worktrunk/.config/worktrunk/config.toml hook pre-start --dry-run --branch=feat/cwt-agent-worktree-launcher`
- `make help`
- stub による `codex` / `wt` 差し替えテストで、`{{ ... }}` を含む task が worktrunk 引数へ直接渡らないことを確認
- Codex による差分限定レビュー: blocking issue なし

## 補足

作業前から存在していた `packages/claude`, `packages/codex`, `packages/git` の未コミット変更は、この PR には含めていません。