### PR TITLE
chore: mise tools を最新版に更新

### DIFF
--- a/packages/mise/.config/mise/config.toml
+++ b/packages/mise/.config/mise/config.toml
@@ -1,7 +1,7 @@
 [tools]
-node = "24.16.0"
-python = "3.14.5"
-"npm:aze-cli" = "0.5.3"
+node = "24.18.0"
+python = "3.14.6"
+"npm:aze-cli" = "0.5.4"
 "npm:shirube" = "1.2.2"
 
 [settings]


### PR DESCRIPTION
## 概要

mise で管理しているツールを、既存のメジャーバージョン方針を維持した最新版へ更新します。

- Node.js: 24.16.0 → 24.18.0（LTS 24 系）
- Python: 3.14.5 → 3.14.6（安定版 3.14 系）
- aze-cli: 0.5.3 → 0.5.4
- shirube: 1.2.2（最新のため変更なし）

## 影響範囲

- packages/mise/.config/mise/config.toml

## 確認

- npx prettier@3 --check .
- git diff --check
- mise install --dry-run node@24.18.0 python@3.14.6 npm:aze-cli@0.5.4 npm:shirube@1.2.2
- cross-review（critical / warning / info: 0 件）