### PR TITLE
feat: Frosted Aqua ターミナルテーマを追加

### DIFF
--- a/packages/git/.gitconfig
+++ b/packages/git/.gitconfig
@@ -34,24 +34,24 @@ hooksPath = ~/.git-hooks
 diffFilter = delta --color-only
 
 [delta]
-# Iceberg dark palette - https://github.com/cocopon/iceberg.vim
+# Frosted Aqua palette
 navigate = true
 line-numbers = true
 syntax-theme = base16
-minus-style = syntax "#3c2a30"
-minus-emph-style = syntax "#5e3a44"
-plus-style = syntax "#293f3a"
-plus-emph-style = syntax "#3a5a52"
+minus-style = syntax "#f4dce2"
+minus-emph-style = syntax "#ebc0ca"
+plus-style = syntax "#dcefe7"
+plus-emph-style = syntax "#b9dfd0"
 zero-style = syntax
-line-numbers-minus-style = "#e27878"
-line-numbers-plus-style = "#b4be82"
-line-numbers-left-style = "#6b7089"
-line-numbers-right-style = "#6b7089"
-line-numbers-zero-style = "#6b7089"
-file-style = "#84a0c6" bold
-file-decoration-style = "#6b7089" ul
-hunk-header-style = "#a093c7" bold
-hunk-header-decoration-style = "#6b7089" box
+line-numbers-minus-style = "#b84f68"
+line-numbers-plus-style = "#3f8969"
+line-numbers-left-style = "#6d8496"
+line-numbers-right-style = "#6d8496"
+line-numbers-zero-style = "#6d8496"
+file-style = "#4c87c7" bold
+file-decoration-style = "#8abdd0" ul
+hunk-header-style = "#8076b3" bold
+hunk-header-decoration-style = "#8abdd0" box
 
 [merge]
 conflictStyle = zdiff3

--- a/packages/lazygit/.config/lazygit/config.yml
+++ b/packages/lazygit/.config/lazygit/config.yml
@@ -1,24 +1,24 @@
-# Iceberg dark - https://github.com/cocopon/iceberg.vim
+# Frosted Aqua palette
 gui:
   theme:
     activeBorderColor:
-      - "#84a0c6"
+      - "#4c87c7"
       - bold
     inactiveBorderColor:
-      - "#6b7089"
+      - "#8abdd0"
     optionsTextColor:
-      - "#84a0c6"
+      - "#5e9bd9"
     selectedLineBgColor:
-      - "#1e2132"
+      - "#c7eaf6"
     selectedRangeBgColor:
-      - "#1e2132"
+      - "#b4dfed"
     cherryPickedCommitBgColor:
-      - "#3a5a52"
+      - "#b9dfd0"
     cherryPickedCommitFgColor:
-      - "#b4be82"
+      - "#3f8969"
     unstagedChangesColor:
-      - "#e27878"
+      - "#b84f68"
     defaultFgColor:
-      - "#c6c8d1"
+      - "#203b52"
   authorColors:
-    "*": "#a093c7"
+    "*": "#8076b3"

--- a/packages/starship/.config/starship.toml
+++ b/packages/starship/.config/starship.toml
@@ -10,18 +10,18 @@ $line_break\
 $character"""
 
 
-# Iceberg palette
+# Frosted Aqua palette
 [directory]
-style = "bold #84a0c6"
+style = "bold #4c87c7"
 
 [character]
-success_symbol = "[❯](#b4be82)"
-error_symbol = "[❯](#e27878)"
-vimcmd_symbol = "[❮](#a093c7)"
+success_symbol = "[❯](#3f8969)"
+error_symbol = "[❯](#b84f68)"
+vimcmd_symbol = "[❮](#8076b3)"
 
 [git_branch]
 format = "[$branch]($style)"
-style = "bold #a093c7"
+style = "bold #5e9bd9"
 
 [git_status]
 format = "[(*$conflicted$untracked$modified$staged$renamed$deleted) ($ahead_behind$stashed)]($style)"

--- a/packages/tig/.tigrc
+++ b/packages/tig/.tigrc
@@ -1,26 +1,26 @@
-# Iceberg-inspired tig color scheme
+# Frosted Aqua-inspired tig color scheme
 # tig は名前付きカラー/256色のみサポートのため近似値を使う
 
-color default            252 233
-color cursor             233 110
-color status             110 233
-color title-blame        233 110
-color title-focus        233 110
-color title-blur         110 233
-color main-date          108 default
-color main-author        140 default
-color main-commit        252 default
-color main-tag           215 default bold
-color main-local-tag     215 default
-color main-remote        108 default
-color main-tracked       108 default bold
-color main-ref           110 default
-color main-head          174 default bold
+color default            24 255
+color cursor             24 153
+color status             24 153
+color title-blame        24 153
+color title-focus        24 153
+color title-blur         67 255
+color main-date          65 default
+color main-author        61 default
+color main-commit        24 default
+color main-tag           136 default bold
+color main-local-tag     136 default
+color main-remote        65 default
+color main-tracked       65 default bold
+color main-ref           67 default
+color main-head          131 default bold
 
-color diff-header        110 default bold
-color diff-chunk         140 default
-color "Reported-by:"     108 default
+color diff-header        67 default bold
+color diff-chunk         61 default
+color "Reported-by:"     65 default
 
-color "    "             default 235
-color "+"                108 default
-color "-"                174 default
+color "    "             default 254
+color "+"                65 default
+color "-"                131 default

--- a/packages/wezterm/.wezterm.lua
+++ b/packages/wezterm/.wezterm.lua
@@ -6,45 +6,122 @@ if wezterm.config_builder then
   config = wezterm.config_builder()
 end
 
--- see https://leaysgur.github.io/wezterm-colorscheme/
--- Iceberg (light) - https://github.com/cocopon/iceberg.vim
-config.color_scheme = 'iceberg-light'
+local tab_bar_background = '#d7f1f8'
+local left_cap = utf8.char(0xe0b6)
+local right_cap = utf8.char(0xe0b4)
+
+-- Frosted Aqua: a pale blue, translucent palette inspired by Liquid Glass.
+config.color_schemes = {
+  ['Frosted Aqua'] = {
+    foreground = '#203b52',
+    background = '#ddf4fa',
+    cursor_bg = '#4c87c7',
+    cursor_fg = '#f4fbfd',
+    cursor_border = '#4c87c7',
+    selection_fg = '#12283a',
+    selection_bg = 'rgba(114, 199, 232, 48%)',
+    split = '#8abdd0',
+    ansi = {
+      '#203b52',
+      '#b84f68',
+      '#3f8969',
+      '#966824',
+      '#4c87c7',
+      '#8076b3',
+      '#378a9b',
+      '#c7eaf6',
+    },
+    brights = {
+      '#6d8496',
+      '#c65f77',
+      '#4b9b79',
+      '#a57432',
+      '#5e9bd9',
+      '#9187c2',
+      '#45a0b1',
+      '#f4fbfd',
+    },
+  },
+}
+config.color_scheme = 'Frosted Aqua'
 
 config.font = wezterm.font_with_fallback {
   { family = "OverpassM Nerd Font" },
   { family = "Moralerspace Argon" },
 }
 
--- Iceberg light palette
 config.window_frame = {
   font = wezterm.font { family = "OverpassM Nerd Font" },
-  active_titlebar_bg = '#e8e9ec',
-  inactive_titlebar_bg = '#dcdfe7',
+  active_titlebar_bg = '#c7eaf6',
+  inactive_titlebar_bg = '#d7f1f8',
+}
+
+config.use_fancy_tab_bar = false
+config.window_decorations = 'INTEGRATED_BUTTONS|RESIZE'
+config.tab_max_width = 32
+config.window_padding = {
+  left = 10,
+  right = 10,
+  top = 6,
+  bottom = 8,
 }
 
 config.colors = {
   tab_bar = {
+    background = tab_bar_background,
     active_tab = {
-      bg_color = '#e8e9ec',
-      fg_color = '#33374c',
+      bg_color = '#d7f1f8',
+      fg_color = '#203b52',
+      intensity = 'Bold',
     },
     inactive_tab = {
-      bg_color = '#dcdfe7',
-      fg_color = '#8b98b6',
+      bg_color = '#d7f1f8',
+      fg_color = '#63869a',
     },
     inactive_tab_hover = {
-      bg_color = '#e8e9ec',
-      fg_color = '#33374c',
+      bg_color = '#d7f1f8',
+      fg_color = '#4c87c7',
     },
     new_tab = {
-      bg_color = '#dcdfe7',
-      fg_color = '#8b98b6',
+      bg_color = '#c7eaf6',
+      fg_color = '#4c87c7',
     },
     new_tab_hover = {
-      bg_color = '#e8e9ec',
-      fg_color = '#33374c',
+      bg_color = '#a9dceb',
+      fg_color = '#12283a',
     },
   },
+}
+
+local function rounded_tab_button(background, foreground, text)
+  return wezterm.format {
+    { Background = { Color = tab_bar_background } },
+    { Text = ' ' },
+    { Foreground = { Color = background } },
+    { Text = left_cap },
+    { Background = { Color = background } },
+    { Foreground = { Color = foreground } },
+    { Text = ' ' .. text .. ' ' },
+    { Background = { Color = tab_bar_background } },
+    { Foreground = { Color = background } },
+    { Text = right_cap },
+  }
+end
+
+config.tab_bar_style = {
+  new_tab = rounded_tab_button('#c7eaf6', '#4c87c7', '+'),
+  new_tab_hover = rounded_tab_button('#a9dceb', '#12283a', '+'),
+}
+
+config.window_background_gradient = {
+  orientation = { Linear = { angle = -35.0 } },
+  colors = { '#e8f8fc', '#c7eaf6', '#d9f3f9' },
+  interpolation = 'Linear',
+  blend = 'Rgb',
+}
+config.inactive_pane_hsb = {
+  saturation = 0.75,
+  brightness = 0.92,
 }
 
 config.front_end = 'WebGpu'
@@ -81,21 +158,46 @@ config.keys = {
 }
 config.window_close_confirmation = 'NeverPrompt'
 
-wezterm.on('format-tab-title', function(tab)
+wezterm.on('format-tab-title', function(tab, tabs, panes, tab_config, hover, max_width)
   local pane = tab.active_pane
   local title = pane.title
-  local cwd = pane.current_working_directory
+  local cwd = pane.current_working_dir
   if cwd then
     local path = cwd.file_path or tostring(cwd)
     local folder = path:match('([^/]+)/?$')
     if folder then
-      return ' ' .. folder .. ': ' .. title .. ' '
+      title = folder .. ': ' .. title
     end
   end
-  return ' ' .. title .. ' '
+
+  local background = '#c7eaf6'
+  local foreground = '#4b6b7e'
+  if tab.is_active then
+    background = '#93d2ea'
+    foreground = '#12283a'
+  elseif hover then
+    background = '#a9dceb'
+    foreground = '#203b52'
+  end
+
+  title = wezterm.truncate_right(title, max_width - 5)
+
+  return {
+    { Background = { Color = tab_bar_background } },
+    { Text = ' ' },
+    { Foreground = { Color = background } },
+    { Text = left_cap },
+    { Background = { Color = background } },
+    { Foreground = { Color = foreground } },
+    { Attribute = { Intensity = tab.is_active and 'Bold' or 'Normal' } },
+    { Text = ' ' .. title .. ' ' },
+    { Background = { Color = tab_bar_background } },
+    { Foreground = { Color = background } },
+    { Text = right_cap },
+  }
 end)
-config.window_background_opacity = 0.9
-config.macos_window_background_blur = 20
+config.window_background_opacity = 0.8
+config.macos_window_background_blur = 32
 config.native_macos_fullscreen_mode = true
 config.initial_cols = 120
 config.initial_rows = 40

--- a/packages/yazi/.config/yazi/theme.toml
+++ b/packages/yazi/.config/yazi/theme.toml
@@ -1,51 +1,51 @@
-# Iceberg dark palette - https://github.com/cocopon/iceberg.vim
+# Frosted Aqua palette
 
 [mgr]
-cwd = { fg = "#84a0c6" }
+cwd = { fg = "#4c87c7" }
 hovered = { reversed = true }
 preview_hovered = { underline = true }
-find_keyword = { fg = "#e2a478", italic = true }
-find_position = { fg = "#a093c7", bg = "reset", italic = true }
-marker_copied = { fg = "#b4be82", bg = "#b4be82" }
-marker_cut = { fg = "#e27878", bg = "#e27878" }
-marker_marked = { fg = "#89b8c2", bg = "#89b8c2" }
-marker_selected = { fg = "#84a0c6", bg = "#84a0c6" }
-tab_active = { fg = "#161821", bg = "#84a0c6" }
-tab_inactive = { fg = "#c6c8d1", bg = "#1e2132" }
+find_keyword = { fg = "#966824", italic = true }
+find_position = { fg = "#8076b3", bg = "reset", italic = true }
+marker_copied = { fg = "#3f8969", bg = "#3f8969" }
+marker_cut = { fg = "#b84f68", bg = "#b84f68" }
+marker_marked = { fg = "#378a9b", bg = "#378a9b" }
+marker_selected = { fg = "#4c87c7", bg = "#4c87c7" }
+tab_active = { fg = "#12283a", bg = "#93d2ea" }
+tab_inactive = { fg = "#203b52", bg = "#c7eaf6" }
 tab_width = 1
 border_symbol = "│"
-border_style = { fg = "#6b7089" }
+border_style = { fg = "#8abdd0" }
 
 [mode]
-normal_main = { fg = "#161821", bg = "#84a0c6", bold = true }
-normal_alt = { fg = "#84a0c6", bg = "#1e2132" }
-select_main = { fg = "#161821", bg = "#b4be82", bold = true }
-select_alt = { fg = "#b4be82", bg = "#1e2132" }
-unset_main = { fg = "#161821", bg = "#a093c7", bold = true }
-unset_alt = { fg = "#a093c7", bg = "#1e2132" }
+normal_main = { fg = "#12283a", bg = "#93d2ea", bold = true }
+normal_alt = { fg = "#4c87c7", bg = "#c7eaf6" }
+select_main = { fg = "#12283a", bg = "#b9dfd0", bold = true }
+select_alt = { fg = "#3f8969", bg = "#c7eaf6" }
+unset_main = { fg = "#12283a", bg = "#cfc9e8", bold = true }
+unset_alt = { fg = "#8076b3", bg = "#c7eaf6" }
 
 [status]
 separator_open = ""
 separator_close = ""
-separator_style = { fg = "#1e2132", bg = "#1e2132" }
-progress_label = { fg = "#c6c8d1", bold = true }
-progress_normal = { fg = "#84a0c6", bg = "#1e2132" }
-progress_error = { fg = "#e27878", bg = "#1e2132" }
-permissions_t = { fg = "#84a0c6" }
-permissions_r = { fg = "#e2a478" }
-permissions_w = { fg = "#e27878" }
-permissions_x = { fg = "#b4be82" }
-permissions_s = { fg = "#6b7089" }
+separator_style = { fg = "#c7eaf6", bg = "#c7eaf6" }
+progress_label = { fg = "#203b52", bold = true }
+progress_normal = { fg = "#4c87c7", bg = "#c7eaf6" }
+progress_error = { fg = "#b84f68", bg = "#c7eaf6" }
+permissions_t = { fg = "#4c87c7" }
+permissions_r = { fg = "#966824" }
+permissions_w = { fg = "#b84f68" }
+permissions_x = { fg = "#3f8969" }
+permissions_s = { fg = "#6d8496" }
 
 [input]
-border = { fg = "#84a0c6" }
+border = { fg = "#4c87c7" }
 title = {}
 value = {}
 selected = { reversed = true }
 
 [confirm]
-border = { fg = "#84a0c6" }
-title = { fg = "#84a0c6" }
+border = { fg = "#4c87c7" }
+title = { fg = "#4c87c7" }
 content = {}
 list = {}
 btn_yes = { reversed = true }
@@ -53,12 +53,12 @@ btn_no = {}
 btn_labels = [ "[Y(es)]", "[(N)o]" ]
 
 [pick]
-border = { fg = "#84a0c6" }
-active = { fg = "#a093c7", bold = true }
+border = { fg = "#4c87c7" }
+active = { fg = "#8076b3", bold = true }
 inactive = {}
 
 [cmp]
-border = { fg = "#84a0c6" }
+border = { fg = "#4c87c7" }
 active = { reversed = true }
 inactive = {}
 icon_file = ""
@@ -66,38 +66,38 @@ icon_folder = ""
 icon_command = ""
 
 [tasks]
-border = { fg = "#84a0c6" }
+border = { fg = "#4c87c7" }
 title = {}
-hovered = { fg = "#a093c7", underline = true }
+hovered = { fg = "#8076b3", underline = true }
 
 [which]
-mask = { bg = "#1e2132" }
-cand = { fg = "#89b8c2" }
-rest = { fg = "#6b7089" }
-desc = { fg = "#a093c7" }
+mask = { bg = "#c7eaf6" }
+cand = { fg = "#378a9b" }
+rest = { fg = "#6d8496" }
+desc = { fg = "#8076b3" }
 separator = "  "
-separator_style = { fg = "#6b7089" }
+separator_style = { fg = "#6d8496" }
 
 [help]
-on = { fg = "#89b8c2" }
-run = { fg = "#a093c7" }
+on = { fg = "#378a9b" }
+run = { fg = "#8076b3" }
 hovered = { reversed = true, bold = true }
-footer = { fg = "#1e2132", bg = "#c6c8d1" }
+footer = { fg = "#12283a", bg = "#c7eaf6" }
 
 [notify]
-title_info = { fg = "#b4be82" }
-title_warn = { fg = "#e2a478" }
-title_error = { fg = "#e27878" }
+title_info = { fg = "#3f8969" }
+title_warn = { fg = "#966824" }
+title_error = { fg = "#b84f68" }
 icon_info = ""
 icon_warn = ""
 icon_error = ""
 
 [filetype]
 rules = [
-  { mime = "image/*", fg = "#e2a478" },
-  { mime = "{audio,video}/*", fg = "#a093c7" },
-  { mime = "application/{zip,rar,7z*,tar,gzip,xz,zstd,bzip*,lzma,compress,archive,cpio,arj,xar,ms-cab*}", fg = "#e27878" },
-  { mime = "application/{pdf,doc,rtf,*office*}", fg = "#89b8c2" },
-  { url = "*", fg = "#c6c8d1" },
-  { url = "*/", fg = "#84a0c6" },
+  { mime = "image/*", fg = "#966824" },
+  { mime = "{audio,video}/*", fg = "#8076b3" },
+  { mime = "application/{zip,rar,7z*,tar,gzip,xz,zstd,bzip*,lzma,compress,archive,cpio,arj,xar,ms-cab*}", fg = "#b84f68" },
+  { mime = "application/{pdf,doc,rtf,*office*}", fg = "#378a9b" },
+  { url = "*", fg = "#203b52" },
+  { url = "*/", fg = "#4c87c7" },
 ]

--- a/packages/zsh/.zshrc
+++ b/packages/zsh/.zshrc
@@ -236,17 +236,18 @@ EOF
 # starship
 eval "$(starship init zsh)"
 
-# Iceberg color palette - https://github.com/cocopon/iceberg.vim
+# Frosted Aqua color palette
 # eza
-export EZA_COLORS="di=1;38;2;132;160;198:ln=38;2;137;184;194:ex=38;2;180;190;130:fi=38;2;198;200;209:*.md=38;2;160;147;199:*.json=38;2;226;164;120:*.lock=38;2;107;112;137:*.toml=38;2;226;164;120:*.yml=38;2;226;164;120:*.yaml=38;2;226;164;120"
+export EZA_COLORS="di=1;38;2;76;135;199:ln=38;2;55;138;155:ex=38;2;63;137;105:fi=38;2;32;59;82:*.md=38;2;128;118;179:*.json=38;2;150;104;36:*.lock=38;2;109;132;150:*.toml=38;2;150;104;36:*.yml=38;2;150;104;36:*.yaml=38;2;150;104;36"
 
 # fzf
 export FZF_DEFAULT_OPTS="
-  --color=fg:#c6c8d1,bg:#161821,hl:#84a0c6
-  --color=fg+:#c6c8d1,bg+:#1e2132,hl+:#84a0c6
-  --color=info:#b4be82,prompt:#a093c7,pointer:#e27878
-  --color=marker:#e2a478,spinner:#89b8c2,header:#84a0c6
-  --color=border:#6b7089"
+  --border=rounded --preview-border=rounded --margin=1 --padding=1,2
+  --color=fg:#203b52,bg:#ddf4fa,hl:#4c87c7
+  --color=fg+:#12283a,bg+:#c7eaf6,hl+:#5e9bd9
+  --color=info:#3f8969,prompt:#8076b3,pointer:#b84f68
+  --color=marker:#966824,spinner:#378a9b,header:#4c87c7
+  --color=border:#8abdd0"
 source <(fzf --zsh)
 
 # zoxide


### PR DESCRIPTION
## 概要

WezTerm を薄い水色の Frosted Aqua テーマへ変更し、Liquid Glass を意識した透過・ぼかし・角丸タブを追加します。関連する CLI ツールも同じカラーパレットへ統一します。

## 変更内容

- WezTerm に Frosted Aqua カラースキーム、背景グラデーション、透過・ぼかしを追加
- WezTerm のタブと新規タブボタンをカプセル型に変更
- Starship、Yazi、FZF、Eza の配色を統一
- Lazygit、Delta、Tig の Git UI 配色を統一
- WezTerm のタブタイトルで正しい current working directory フィールドを参照

## 確認内容

- wezterm の設定読み込みと GUI 起動
- zsh -n packages/zsh/.zshrc
- starship の設定読み込み
- yazi --debug
- FZF オプションの読み込み
- git config の設定読み込み
- Prettier による TOML/YAML フォーマット確認
- git diff --check
- Codex CLI による commit レビュー（blocking 指摘なし）