### PR TITLE
chore: update shirube to 1.3.1

### DIFF
--- a/packages/mise/.config/mise/config.toml
+++ b/packages/mise/.config/mise/config.toml
@@ -2,7 +2,7 @@
 node = "26.5.0"
 python = "3.14.6"
 "npm:aze-cli" = "0.5.4"
-"npm:shirube" = "1.3.0"
+"npm:shirube" = "1.3.1"
 
 [settings]
 idiomatic_version_file_enable_tools = ["python", "node"]


### PR DESCRIPTION
## 概要

mise で管理している `shirube` を 1.3.0 から 1.3.1 に更新します。

## 変更内容

- `packages/mise/.config/mise/config.toml` の `npm:shirube` を 1.3.1 に更新

## 確認内容

- `npm view shirube@1.3.1 version dist.tarball repository.url --json`
- `mise install --dry-run npm:shirube@1.3.1`
- `git diff --check -- packages/mise/.config/mise/config.toml`