### PR TITLE
fix: shirubeのbetter-sqlite3ビルドを許可する

### DIFF
--- a/packages/mise/.config/mise/config.toml
+++ b/packages/mise/.config/mise/config.toml
@@ -2,7 +2,7 @@
 node = "26.5.0"
 python = "3.14.6"
 "npm:aze-cli" = "0.5.4"
-"npm:shirube" = "1.3.1"
+"npm:shirube" = { version = "1.3.1", allow_builds = ["better-sqlite3"] }
 
 [settings]
 idiomatic_version_file_enable_tools = ["python", "node"]


### PR DESCRIPTION
## 概要

mise の npm backend がインストールスクリプトを既定で無効化するため、shirube 1.3.1 が依存する better-sqlite3 の native binary を生成・取得できない問題を修正します。

## 変更内容

- npm:shirube の設定に allow_builds = ["better-sqlite3"] を追加
- shirube のインストール時に --allow-scripts=better-sqlite3 が渡されるように変更

参考: https://mise.jdx.dev/dev-tools/backends/npm.html

## 確認内容

- better_sqlite3.node の配置成功
- shirube --version で 1.3.1 を確認
- Node.js 26.5.0 で DB 作成成功
- shirube add / shirube list の動作成功
- mise が設定を読み込み、npm install に --allow-scripts=better-sqlite3 を渡すことを確認
- Codex レビューで指摘なし