### PR TITLE
fix: WezTermのタブにディレクトリ名のみ表示する

### DIFF
--- a/packages/wezterm/.wezterm.lua
+++ b/packages/wezterm/.wezterm.lua
@@ -166,7 +166,7 @@ wezterm.on('format-tab-title', function(tab, tabs, panes, tab_config, hover, max
     local path = cwd.file_path or tostring(cwd)
     local folder = path:match('([^/]+)/?$')
     if folder then
-      title = folder .. ': ' .. title
+      title = folder
     end
   end
 


### PR DESCRIPTION
## 概要

WezTerm のタブタイトルから重複していた pane title を除き、カレントディレクトリ名のみ表示するよう変更します。

## 変更内容

- `packages/wezterm/.wezterm.lua` の `format-tab-title` を変更
- cwd を取得できる場合、末尾のディレクトリ名だけをタブタイトルに使用
- cwd を取得できない場合は、従来どおり `pane.title` をフォールバックとして使用

## 確認内容

- `wezterm --config-file packages/wezterm/.wezterm.lua show-keys --lua`
- `npx prettier@3 --check packages/wezterm/.wezterm.lua`
- 対象ファイルの `git diff --check`
- Codex CLI による cross-review（指摘なし）