### PR TITLE
feat: dotfilesの状態を検査するmake doctorを追加する

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: install update sync link unlink clean-legacy-claude-skills-stow setup-python-tools setup-uv-tools setup-pipx-tools setup-mcp setup-claude-mcp setup-codex-mcp skills-install promote-webfetch help
+.PHONY: install update sync link unlink doctor clean-legacy-claude-skills-stow setup-python-tools setup-uv-tools setup-pipx-tools setup-mcp setup-claude-mcp setup-codex-mcp skills-install promote-webfetch help
 
 PACKAGES := zsh vim wezterm git npm starship yazi bat tig lazygit claude codex copilot worktrunk gh-dash mise pnpm atuin
 UV_TOOLS_FILE := packages/python-tools/.default-uv-tools
@@ -25,6 +25,31 @@ link: ## Create symlinks with stow and install agent skills via gh skill
 unlink: ## Remove symlinks with stow
 	$(MAKE) clean-legacy-claude-skills-stow
 	cd packages && stow -v --no-folding -D -t ~ $(PACKAGES)
+
+doctor: ## Check dotfiles setup without making changes
+	@status=0; \
+	run_check() { \
+		name="$$1"; \
+		shift; \
+		printf '\n==> %s\n' "$$name"; \
+		if "$$@"; then \
+			printf '[PASS] %s\n' "$$name"; \
+		else \
+			printf '[FAIL] %s\n' "$$name" >&2; \
+			status=1; \
+		fi; \
+	}; \
+	run_check "Homebrew dependencies" brew bundle check --verbose --file=Brewfile; \
+	run_check "Stow links" stow --simulate --verbose --no-folding --dir=packages --target="$$HOME" $(PACKAGES); \
+	run_check "zsh syntax" zsh -n packages/zsh/.zshrc; \
+	run_check "mise installation" mise doctor; \
+	printf '\n'; \
+	if [ "$$status" -eq 0 ]; then \
+		printf 'All checks passed.\n'; \
+	else \
+		printf 'One or more checks failed.\n' >&2; \
+	fi; \
+	exit "$$status"
 
 clean-legacy-claude-skills-stow: ## Remove old Stow links for legacy Claude Code skills package
 	@if [ -L "$$HOME/.claude/skills" ]; then \

--- a/Makefile
+++ b/Makefile
@@ -39,8 +39,18 @@ doctor: ## Check dotfiles setup without making changes
 			status=1; \
 		fi; \
 	}; \
+	check_stow() { \
+		output=$$(stow --simulate --verbose --no-folding --dir=packages --target="$$HOME" $(PACKAGES) 2>&1); \
+		stow_status=$$?; \
+		[ -z "$$output" ] || printf '%s\n' "$$output"; \
+		[ "$$stow_status" -eq 0 ] || return "$$stow_status"; \
+		if printf '%s\n' "$$output" | grep -Eq '^(LINK|MKDIR):'; then \
+			printf 'Stow would create links or directories.\n' >&2; \
+			return 1; \
+		fi; \
+	}; \
 	run_check "Homebrew dependencies" brew bundle check --verbose --file=Brewfile; \
-	run_check "Stow links" stow --simulate --verbose --no-folding --dir=packages --target="$$HOME" $(PACKAGES); \
+	run_check "Stow links" check_stow; \
 	run_check "zsh syntax" zsh -n packages/zsh/.zshrc; \
 	run_check "mise installation" mise doctor; \
 	printf '\n'; \

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ make install
 | `make install`            | 初回セットアップ                                          |
 | `make link`               | `packages/` 配下を `$HOME` に stow でシンボリックリンク化 |
 | `make unlink`             | stow 管理のシンボリックリンクを削除                       |
+| `make doctor`             | dotfiles の設定状態を読み取り専用で検査                   |
 | `make update`             | `Brewfile` から Homebrew パッケージを更新                 |
 | `make sync`               | 現在の Homebrew 状態を `Brewfile` に書き戻し              |
 | `make setup-python-tools` | OpenHands などの Python CLI ツールをインストール          |


### PR DESCRIPTION
close #371

## 概要

Homebrew、Stow、zsh、mise の状態を読み取り専用でまとめて検査する `make doctor` を追加しました。各検査の成否を個別に表示し、失敗後も残りの検査を続行して、最後に全体の終了コードを返します。

Stow は dry-run の終了コードだけでなく、リンクやディレクトリの作成予定もドリフトとして検出します。

## 変更箇所

- `Makefile`: `doctor` ターゲットと検査結果の集約処理を追加
- `README.md`: 主要コマンド一覧に `make doctor` を追加

## ローカル検証

- `make help`
- `make doctor`（実環境のドリフトを検出しつつ全検査が続行することを確認）
- 成功・失敗コマンドのスタブによる終了コードと後続実行の確認
- 空の HOME を使った Stow 変更予定の検出確認
- `npx prettier@3 --check .`
- `git diff --check`