### PR TITLE
refactor: 開発CLIの宣言元をmiseへ統一する

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,7 +21,7 @@ packages/           # Stow パッケージ（各ツールの設定ファイル�
 ├── vim/           # .vimrc
 ├── wezterm/       # .wezterm.lua
 ├── git/           # .gitconfig, .gitignore_global
-├── npm/           # .default-npm-packages
+├── mise/          # .config/mise/config.toml（開発 CLI の宣言元）
 ├── starship/      # .config/starship.toml
 ├── yazi/          # .config/yazi/yazi.toml
 ├── claude/        # .claude/settings.json, .claude/CLAUDE.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -48,8 +48,8 @@ Use `make` targets as the standard workflow:
 - `make sync`: 現在の Homebrew 状態を `Brewfile` に書き戻す。
 - `make link`: `packages/` 配下を `$HOME` に stow でシンボリックリンク化。
 - `make unlink`: stow 管理のシンボリックリンクを削除。
+- `mise install`: mise 管理の開発 CLI と Terraform をインストール。
 - `make setup-mcp`: Claude Code の MCP サーバーをセットアップ。
-- `make setup-python-tools`: OpenHands などの Python CLI ツールを `uv` / `pipx` 経由でインストール。
 
 Example: `make link` after adding a new file under `packages/zsh/`.
 

--- a/Brewfile
+++ b/Brewfile
@@ -39,7 +39,6 @@ brew "yazi"
 brew "glow"
 brew "freeze"
 brew "mise"
-brew "pipx"
 brew "uv"
 
 # --- Container & VM ---
@@ -47,7 +46,6 @@ brew "podman"
 cask "orbstack"
 
 # --- Cloud & IaC ---
-brew "tfenv"
 brew "tflint"
 brew "awscli"
 cask "gcloud-cli"

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,6 @@
-.PHONY: install update sync link unlink doctor clean-legacy-claude-skills-stow setup-python-tools setup-uv-tools setup-pipx-tools setup-mcp setup-claude-mcp setup-codex-mcp skills-install promote-webfetch help
+.PHONY: install update sync link unlink doctor clean-legacy-claude-skills-stow setup-mcp setup-claude-mcp setup-codex-mcp skills-install promote-webfetch help
 
-PACKAGES := zsh vim wezterm git npm starship yazi bat tig lazygit claude codex copilot worktrunk gh-dash mise pnpm atuin
-UV_TOOLS_FILE := packages/python-tools/.default-uv-tools
-PIPX_TOOLS_FILE := packages/python-tools/.default-pipx-tools
+PACKAGES := zsh vim wezterm git starship yazi bat tig lazygit claude codex copilot worktrunk gh-dash mise pnpm atuin
 
 help: ## Show this help
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-15s\033[0m %s\n", $$1, $$2}'
@@ -84,20 +82,6 @@ skills-install: ## Install agent skills globally via gh skill
 	gh skill install anthropics/skills frontend-design --agent claude-code --scope user -f
 	gh skill install anthropics/skills skill-creator --agent claude-code --scope user -f
 	gh skill install vercel-labs/agent-browser agent-browser --agent claude-code --scope user -f
-
-setup-python-tools: setup-uv-tools setup-pipx-tools ## Install Python CLI tools
-
-setup-uv-tools: ## Install Python CLI tools via uv
-	@while read -r package python; do \
-		case "$$package" in ""|\#*) continue;; esac; \
-		uv tool install "$$package" --python "$$python"; \
-	done < "$(UV_TOOLS_FILE)"
-
-setup-pipx-tools: ## Install Python CLI tools via pipx
-	@while read -r package python; do \
-		case "$$package" in ""|\#*) continue;; esac; \
-		pipx install "$$package" --python "$$python"; \
-	done < "$(PIPX_TOOLS_FILE)"
 
 setup-mcp: setup-claude-mcp setup-codex-mcp ## Setup MCP servers for AI coding agents
 

--- a/README.md
+++ b/README.md
@@ -18,16 +18,16 @@ make install
 
 ## 主要コマンド
 
-| Command                   | 用途                                                      |
-| ------------------------- | --------------------------------------------------------- |
-| `make help`               | 利用可能なタスク一覧を表示                                |
-| `make install`            | 初回セットアップ                                          |
-| `make link`               | `packages/` 配下を `$HOME` に stow でシンボリックリンク化 |
-| `make unlink`             | stow 管理のシンボリックリンクを削除                       |
-| `make doctor`             | dotfiles の設定状態を読み取り専用で検査                   |
-| `make update`             | `Brewfile` から Homebrew パッケージを更新                 |
-| `make sync`               | 現在の Homebrew 状態を `Brewfile` に書き戻し              |
-| `make setup-python-tools` | OpenHands などの Python CLI ツールをインストール          |
+| Command        | 用途                                                      |
+| -------------- | --------------------------------------------------------- |
+| `make help`    | 利用可能なタスク一覧を表示                                |
+| `make install` | 初回セットアップ                                          |
+| `make link`    | `packages/` 配下を `$HOME` に stow でシンボリックリンク化 |
+| `make unlink`  | stow 管理のシンボリックリンクを削除                       |
+| `make doctor`  | dotfiles の設定状態を読み取り専用で検査                   |
+| `make update`  | `Brewfile` から Homebrew パッケージを更新                 |
+| `make sync`    | 現在の Homebrew 状態を `Brewfile` に書き戻し              |
+| `mise install` | mise 管理の開発 CLI と Terraform をインストール           |
 
 ## 詳細
 

--- a/install.sh
+++ b/install.sh
@@ -19,6 +19,9 @@ brew bundle install --cleanup --force-cleanup --file=Brewfile
 printf '\n-- create symbolic links with stow --\n'
 make link
 
+printf '\n-- install development CLI tools with mise --\n'
+mise install
+
 printf '\n-- install gh extensions --\n'
 gh extension install dlvhdr/gh-dash || true
 gh extension install babarot/gh-infra || true

--- a/packages/mise/.config/mise/config.toml
+++ b/packages/mise/.config/mise/config.toml
@@ -1,8 +1,17 @@
 [tools]
 node = "26.5.0"
 python = "3.14.6"
+terraform = "1.15.8"
 "npm:aze-cli" = "0.5.4"
+"npm:agent-browser" = "0.31.1"
 "npm:shirube" = { version = "1.3.1", allow_builds = ["better-sqlite3"] }
+"npm:socket" = "1.1.140"
+"pipx:drawio2pptx" = "0.0.2"
+"pipx:headroom-ai" = { version = "0.23.0", extras = "proxy" }
+"pipx:openhands" = { version = "1.16.0", uvx_args = "--python 3.12" }
+# v0.0.90 is the spec-kit release whose Python package version is specify-cli 0.0.22.
+"pipx:github/spec-kit" = "v0.0.90"
+"pipx:twitter-cli" = "0.8.5"
 
 [settings]
 idiomatic_version_file_enable_tools = ["python", "node"]

--- a/packages/npm/.default-npm-packages
+++ b/packages/npm/.default-npm-packages
@@ -1,3 +1,0 @@
-# mise Default Node Packages
-agent-browser
-socket

--- a/packages/python-tools/.default-pipx-tools
+++ b/packages/python-tools/.default-pipx-tools
@@ -1,1 +1,0 @@
-# package python

--- a/packages/python-tools/.default-uv-tools
+++ b/packages/python-tools/.default-uv-tools
@@ -1,2 +1,0 @@
-# package python
-openhands 3.12

--- a/packages/zsh/.zshrc
+++ b/packages/zsh/.zshrc
@@ -255,7 +255,7 @@ eval "$(zoxide init zsh)"
 
 # Terraform
 autoload -U +X bashcompinit && bashcompinit
-complete -o nospace -C /opt/homebrew/bin/terraform terraform
+complete -o nospace -C terraform terraform
 
 # mise
 eval "$(/opt/homebrew/bin/mise activate zsh)"


### PR DESCRIPTION
close #365

## 目的

Node CLI、Python CLI、Terraform の宣言元を `packages/mise/.config/mise/config.toml` に統一し、`mise install` で開発 CLI を再現できるようにします。

## 変更内容

- `packages/mise/` に npm / pipx backend の CLI と Terraform の固定バージョンを追加
- OpenHands の Python 3.12 指定、headroom の proxy extra、spec-kit の再現可能な GitHub tag を設定
- `packages/npm/`、`packages/python-tools/` の旧 tool list と専用 Make target を削除
- `Brewfile` から pipx / tfenv を削除し、Homebrew の uv を維持
- mise 管理の Terraform を参照するよう zsh 補完を更新
- `install.sh` で Stow 後に `mise install` を実行し、README / AGENTS の導線を更新

## 影響範囲

- `packages/mise/`
- `packages/zsh/`
- `packages/npm/`
- `packages/python-tools/`
- `Brewfile`
- `Makefile`
- `install.sh`
- `README.md` / `AGENTS.md`

## 検証

- `mise install`
- `mise ls --current`
- 各 CLI の version / help コマンド
- `zsh -n packages/zsh/.zshrc`
- mise 管理 Terraform の zsh 補完定義確認
- `make help`
- `brew bundle check --file=Brewfile`
- `npx prettier@3 --check .`