### PR TITLE
refactor: Stowのlink処理とagent skill更新を分離する

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: install update sync link unlink doctor clean-legacy-claude-skills-stow setup-mcp setup-claude-mcp setup-codex-mcp skills-install promote-webfetch help
+.PHONY: install update sync link unlink doctor clean-legacy-claude-skills-stow setup-mcp setup-claude-mcp setup-codex-mcp skills-install skills-update promote-webfetch help
 
 PACKAGES := zsh vim wezterm git starship yazi bat tig lazygit claude codex copilot worktrunk gh-dash mise pnpm atuin
 
@@ -15,10 +15,9 @@ update: ## Update Homebrew itself and packages from Brewfile
 sync: ## Sync current Homebrew packages to Brewfile
 	brew bundle dump --force --file=Brewfile
 
-link: ## Create symlinks with stow and install agent skills via gh skill
+link: ## Create symlinks with stow
 	$(MAKE) clean-legacy-claude-skills-stow
 	cd packages && stow -v --no-folding -t ~ $(PACKAGES)
-	$(MAKE) skills-install
 
 unlink: ## Remove symlinks with stow
 	$(MAKE) clean-legacy-claude-skills-stow
@@ -82,6 +81,9 @@ skills-install: ## Install agent skills globally via gh skill
 	gh skill install anthropics/skills frontend-design --agent claude-code --scope user -f
 	gh skill install anthropics/skills skill-creator --agent claude-code --scope user -f
 	gh skill install vercel-labs/agent-browser agent-browser --agent claude-code --scope user -f
+
+skills-update: ## Update installed agent skills via gh skill
+	gh skill update --all
 
 setup-mcp: setup-claude-mcp setup-codex-mcp ## Setup MCP servers for AI coding agents
 

--- a/README.md
+++ b/README.md
@@ -14,20 +14,22 @@ macOS 向けの dotfiles リポジトリ。Homebrew でパッケージ管理、[
 make install
 ```
 
-`install.sh` 経由で Homebrew のインストール、`Brewfile` のパッケージ導入、`packages/` 配下のシンボリックリンク作成までを行う。
+`install.sh` 経由で Homebrew のインストール、`Brewfile` のパッケージ導入、`packages/` 配下のシンボリックリンク作成、agent skill の導入までを行う。
 
 ## 主要コマンド
 
-| Command        | 用途                                                      |
-| -------------- | --------------------------------------------------------- |
-| `make help`    | 利用可能なタスク一覧を表示                                |
-| `make install` | 初回セットアップ                                          |
-| `make link`    | `packages/` 配下を `$HOME` に stow でシンボリックリンク化 |
-| `make unlink`  | stow 管理のシンボリックリンクを削除                       |
-| `make doctor`  | dotfiles の設定状態を読み取り専用で検査                   |
-| `make update`  | `Brewfile` から Homebrew パッケージを更新                 |
-| `make sync`    | 現在の Homebrew 状態を `Brewfile` に書き戻し              |
-| `mise install` | mise 管理の開発 CLI と Terraform をインストール           |
+| Command               | 用途                                                      |
+| --------------------- | --------------------------------------------------------- |
+| `make help`           | 利用可能なタスク一覧を表示                                |
+| `make install`        | 初回セットアップ（agent skill の導入を含む）              |
+| `make link`           | `packages/` 配下を `$HOME` に stow でシンボリックリンク化 |
+| `make unlink`         | stow 管理のシンボリックリンクを削除                       |
+| `make skills-install` | 管理対象の agent skill を初回導入・再導入                 |
+| `make skills-update`  | インストール済みの agent skill を最新版へ更新             |
+| `make doctor`         | dotfiles の設定状態を読み取り専用で検査                   |
+| `make update`         | `Brewfile` から Homebrew パッケージを更新                 |
+| `make sync`           | 現在の Homebrew 状態を `Brewfile` に書き戻し              |
+| `mise install`        | mise 管理の開発 CLI と Terraform をインストール           |
 
 ## 詳細
 

--- a/install.sh
+++ b/install.sh
@@ -19,6 +19,9 @@ brew bundle install --cleanup --force-cleanup --file=Brewfile
 printf '\n-- create symbolic links with stow --\n'
 make link
 
+printf '\n-- install agent skills --\n'
+make skills-install
+
 printf '\n-- install development CLI tools with mise --\n'
 mise install
 


### PR DESCRIPTION
close #364

## 概要

`make link` を Stow によるシンボリックリンク作成へ限定し、agent skill の初回導入と更新を独立した Make ターゲットに分離します。

## 変更内容

- `Makefile`: `make link` から skill 導入を外し、`skills-update` を追加
- `install.sh`: 初回セットアップで `skills-install` を明示的に実行
- `README.md`: link・skill 導入・skill 更新の使い分けを追記

## ローカル検証

- `make help`
- `make -n link`
- `make -n skills-install`
- `make -n skills-update`
- `gh skill update --dry-run`
- `bash -n install.sh`
- `npx prettier@3 --check .`