### PR TITLE
chore: GitHub Actionsをv6へ更新し最小権限化する

### DIFF
--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -4,11 +4,14 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   actionlint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Download actionlint
         id: get_actionlint
         run: bash <(curl https://raw.githubusercontent.com/rhysd/actionlint/v1.7.12/scripts/download-actionlint.bash) 1.7.12

--- a/.github/workflows/prettier.yml
+++ b/.github/workflows/prettier.yml
@@ -4,12 +4,15 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   prettier:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
         with:
           node-version: "22"
       - run: npx prettier@3 --check .

--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -4,11 +4,14 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   shellcheck:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: ludeeus/action-shellcheck@2.0.0
         with:
           ignore_paths: packages/zsh


### PR DESCRIPTION
close #363

## 概要

GitHub Actions で利用する `actions/checkout` と `actions/setup-node` を v6 に更新し、各 workflow の `GITHUB_TOKEN` 権限を読み取り専用に制限します。

## 変更内容

- `.github/workflows/actionlint.yml` の checkout を v6 に更新し、`contents: read` を設定
- `.github/workflows/prettier.yml` の checkout / setup-node を v6 に更新し、`contents: read` を設定
- `.github/workflows/shellcheck.yml` の checkout を v6 に更新し、`contents: read` を設定
- Prettier workflow の `node-version: "22"` は維持

## 検証

- `actionlint -color`
- `npx prettier@3 --check .`
- workflow 3件の checkout v6 / permissions 設定を検索で確認
- Prettier workflow の setup-node v6 / Node.js 22 を検索で確認