### PR TITLE
refactor: Makefileのセットアップワークフローを整理

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -81,5 +81,5 @@ There is no centralized automated test suite in this repository.
 - Keep commit scope small and message specific (example: `fix: adjust yazi preview keymap`).
 - Open PRs with:
   - purpose and impacted package paths,
-  - local verification steps (`make link`, `make help`, etc.),
+  - local verification steps (`make stow-link`, `make help`, etc.),
   - screenshots/log snippets only when UI behavior changes.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,15 +43,20 @@ packages/           # Stow パッケージ（各ツールの設定ファイル�
 Use `make` targets as the standard workflow:
 
 - `make help`: 利用可能なタスク一覧を表示。
-- `make install`: 初回セットアップ（Homebrew インストール、パッケージインストール、シンボリックリンク作成）を `install.sh` 経由で実行。
-- `make update`: `Brewfile` から Homebrew パッケージを更新。
-- `make sync`: 現在の Homebrew 状態を `Brewfile` に書き戻す。
-- `make link`: `packages/` 配下を `$HOME` に stow でシンボリックリンク化。
-- `make unlink`: stow 管理のシンボリックリンクを削除。
-- `mise install`: mise 管理の開発 CLI と Terraform をインストール。
-- `make setup-mcp`: Claude Code の MCP サーバーをセットアップ。
+- `make install`: Homebrew のbootstrapから外部リソース導入、状態検査までを一括実行。
+- `make update`: 管理対象のパッケージと外部リソースを一括更新。
+- `make brew-install`: `Brewfile` のパッケージをインストール。
+- `make brew-update`: Homebrew と `Brewfile` のパッケージを更新。
+- `make brewfile-dump`: 現在の Homebrew 状態を `Brewfile` に書き出す。
+- `make brew-prune`: `Brewfile` にない Homebrew パッケージを確認後に削除。
+- `make stow-link`: `packages/` 配下を `$HOME` にシンボリックリンク化。
+- `make stow-unlink`: Stow 管理のシンボリックリンクを削除。
+- `make mise-install`: mise 管理の開発 CLI と Terraform をインストール。
+- `make mcp-setup`: Claude Code と Codex の MCP サーバーをセットアップ。
 
-Example: `make link` after adding a new file under `packages/zsh/`.
+MCP設定はStow管理対象の設定ファイルと衝突し得るため、`make install` には含めず明示的に実行する。
+
+Example: `make stow-link` after adding a new file under `packages/zsh/`.
 
 ## Coding Style & Naming Conventions
 
@@ -66,7 +71,7 @@ Prettier is configured as the formatter. Run `npx prettier@3 --check .` to verif
 
 There is no centralized automated test suite in this repository.
 
-- Verify symlink behavior with `make link` and `make unlink`.
+- Verify symlink behavior with `make stow-link` and `make stow-unlink`.
 - Run `make help` to confirm Makefile integrity after edits.
 - For tool-specific configs, run the tool’s own check command when available (for example, `git config --list`).
 

--- a/Makefile
+++ b/Makefile
@@ -1,29 +1,132 @@
-.PHONY: install update sync link unlink doctor clean-legacy-claude-skills-stow setup-mcp setup-claude-mcp setup-codex-mcp skills-install skills-update promote-webfetch help
+.DEFAULT_GOAL := help
 
 PACKAGES := zsh vim wezterm git starship yazi bat tig lazygit claude codex copilot worktrunk gh-dash mise pnpm atuin
 
-help: ## Show this help
-	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-15s\033[0m %s\n", $$1, $$2}'
+.PHONY: help install _install update doctor \
+	brew-install brew-update brewfile-dump brew-prune \
+	stow-link stow-unlink _clean-legacy-claude-skills-stow \
+	mise-install skills-install skills-update \
+	gh-extensions-install gh-extensions-update \
+	gitalias-install gitalias-update \
+	vim-plugins-install vim-plugins-update bat-cache-build \
+	mcp-setup claude-mcp-setup codex-mcp-setup \
+	claude-permissions-promote
 
-install: ## Run install.sh to setup dotfiles
+help: ## 利用可能なタスク一覧を表示
+	@awk 'BEGIN {FS = ":.*## "} /^[a-zA-Z][a-zA-Z0-9_-]*:.*## / {names[count] = $$1; descriptions[count] = $$2; if (length($$1) > width) width = length($$1); count++} END {for (i = 0; i < count; i++) printf "\033[36m%-*s\033[0m %s\n", width + 2, names[i], descriptions[i]}' $(MAKEFILE_LIST)
+
+install: ## dotfiles 環境を初回セットアップ
 	./install.sh
 
-update: ## Update Homebrew itself and packages from Brewfile
-	brew update
-	brew bundle --file=Brewfile
+_install:
+	$(MAKE) brew-install
+	$(MAKE) stow-link
+	$(MAKE) mise-install
+	$(MAKE) skills-install
+	$(MAKE) gh-extensions-install
+	$(MAKE) gitalias-install
+	$(MAKE) vim-plugins-install
+	$(MAKE) bat-cache-build
+	$(MAKE) doctor
 
-sync: ## Sync current Homebrew packages to Brewfile
+update: ## 管理対象のパッケージと外部リソースを更新
+	$(MAKE) brew-update
+	$(MAKE) skills-update
+	$(MAKE) gh-extensions-update
+	$(MAKE) gitalias-update
+	$(MAKE) vim-plugins-update
+	$(MAKE) bat-cache-build
+
+brew-install: ## Brewfile のパッケージをインストール
+	brew bundle install --file=Brewfile
+
+brew-update: ## Homebrew と Brewfile のパッケージを更新
+	brew update
+	brew bundle install --file=Brewfile
+
+brewfile-dump: ## 現在の Homebrew 状態を Brewfile に書き出し
 	brew bundle dump --force --file=Brewfile
 
-link: ## Create symlinks with stow
-	$(MAKE) clean-legacy-claude-skills-stow
-	cd packages && stow -v --no-folding -t ~ $(PACKAGES)
+brew-prune: ## Brewfile にない Homebrew パッケージを確認後に削除
+	brew bundle cleanup --file=Brewfile
 
-unlink: ## Remove symlinks with stow
-	$(MAKE) clean-legacy-claude-skills-stow
-	cd packages && stow -v --no-folding -D -t ~ $(PACKAGES)
+stow-link: ## packages 配下をホームディレクトリへリンク
+	$(MAKE) _clean-legacy-claude-skills-stow
+	cd packages && stow -v --no-folding -t "$$HOME" $(PACKAGES)
 
-doctor: ## Check dotfiles setup without making changes
+stow-unlink: ## Stow 管理のシンボリックリンクを削除
+	$(MAKE) _clean-legacy-claude-skills-stow
+	cd packages && stow -v --no-folding -D -t "$$HOME" $(PACKAGES)
+
+_clean-legacy-claude-skills-stow:
+	@if [ -L "$$HOME/.claude/skills" ]; then \
+		target=$$(readlink "$$HOME/.claude/skills"); \
+		case "$$target" in *packages/claude-skills/.claude/skills*) rm -f "$$HOME/.claude/skills" ;; esac; \
+	fi
+	@if [ -d "$$HOME/.claude/skills" ]; then \
+		find "$$HOME/.claude/skills" -type l -print 2>/dev/null | while IFS= read -r link; do \
+			target=$$(readlink "$$link"); \
+			case "$$target" in *packages/claude-skills/.claude/skills/*) rm -f "$$link" ;; esac; \
+		done; \
+	fi
+
+mise-install: ## mise 管理の開発ツールをインストール
+	mise install
+
+skills-install: ## 管理対象の agent skill をインストール
+	gh skill install hirokisakabe/issuekit acceptance-check --agent claude-code --scope user -f
+	gh skill install hirokisakabe/issuekit cross-review --agent claude-code --scope user -f
+	gh skill install hirokisakabe/issuekit issue-create --agent claude-code --scope user -f
+	gh skill install hirokisakabe/issuekit issue-implement --agent claude-code --scope user -f
+	gh skill install hirokisakabe/issuekit issue-pick --agent claude-code --scope user -f
+	gh skill install hirokisakabe/issuekit issue-refine --agent claude-code --scope user -f
+	gh skill install hirokisakabe/issuekit worktree-start --agent claude-code --scope user -f
+	gh skill install anthropics/skills frontend-design --agent claude-code --scope user -f
+	gh skill install anthropics/skills skill-creator --agent claude-code --scope user -f
+	gh skill install vercel-labs/agent-browser agent-browser --agent claude-code --scope user -f
+
+skills-update: ## インストール済みの agent skill を更新
+	gh skill update --all
+
+gh-extensions-install: ## 管理対象の GitHub CLI 拡張をインストール
+	gh extension install dlvhdr/gh-dash --force
+	gh extension install babarot/gh-infra --force
+
+gh-extensions-update: ## インストール済みの GitHub CLI 拡張を更新
+	gh extension upgrade --all
+
+gitalias-install: ## GitAlias をインストール
+	mkdir -p "$$HOME/.git-extensions"
+	curl -fsSL https://raw.githubusercontent.com/GitAlias/gitalias/main/gitalias.txt -o "$$HOME/.git-extensions/gitalias.txt"
+
+gitalias-update: gitalias-install ## GitAlias を更新
+
+vim-plugins-install: ## 管理対象の Vim プラグインをインストール
+	@if [ ! -d "$$HOME/.vim/pack/themes/start/iceberg.vim" ]; then \
+		mkdir -p "$$HOME/.vim/pack/themes/start"; \
+		git clone --depth 1 https://github.com/cocopon/iceberg.vim.git "$$HOME/.vim/pack/themes/start/iceberg.vim"; \
+	fi
+
+vim-plugins-update: vim-plugins-install ## 管理対象の Vim プラグインを更新
+	git -C "$$HOME/.vim/pack/themes/start/iceberg.vim" pull --ff-only
+
+bat-cache-build: ## bat のテーマキャッシュを再構築
+	bat cache --build
+
+mcp-setup: claude-mcp-setup codex-mcp-setup ## AI coding agent の MCP サーバーを設定
+
+claude-mcp-setup: ## Claude Code の MCP サーバーを設定
+	@claude mcp get chrome-devtools >/dev/null 2>&1 || \
+		claude mcp add --scope user --transport stdio chrome-devtools -- npx chrome-devtools-mcp@latest
+
+codex-mcp-setup: ## Codex の MCP サーバーを設定
+	@codex mcp get chrome-devtools >/dev/null 2>&1 || \
+		codex mcp add chrome-devtools -- npx chrome-devtools-mcp@latest
+
+claude-permissions-promote: ## WebFetch 履歴のドメインを Claude Code の許可設定へ反映
+	./scripts/promote-webfetch.sh
+
+doctor: ## dotfiles のセットアップ状態を読み取り専用で検査
 	@status=0; \
 	run_check() { \
 		name="$$1"; \
@@ -46,10 +149,19 @@ doctor: ## Check dotfiles setup without making changes
 			return 1; \
 		fi; \
 	}; \
+	check_gh_extensions() { \
+		output=$$(gh extension list); \
+		printf '%s\n' "$$output" | grep -Fq 'dlvhdr/gh-dash' && \
+			printf '%s\n' "$$output" | grep -Fq 'babarot/gh-infra'; \
+	}; \
 	run_check "Homebrew dependencies" brew bundle check --verbose --file=Brewfile; \
 	run_check "Stow links" check_stow; \
 	run_check "zsh syntax" zsh -n packages/zsh/.zshrc; \
 	run_check "mise installation" mise doctor; \
+	run_check "GitHub CLI extensions" check_gh_extensions; \
+	run_check "GitAlias" test -f "$$HOME/.git-extensions/gitalias.txt"; \
+	run_check "Vim plugins" test -d "$$HOME/.vim/pack/themes/start/iceberg.vim"; \
+	run_check "bat theme cache" sh -c 'bat --list-themes | grep -Fxq Iceberg'; \
 	printf '\n'; \
 	if [ "$$status" -eq 0 ]; then \
 		printf 'All checks passed.\n'; \
@@ -57,41 +169,3 @@ doctor: ## Check dotfiles setup without making changes
 		printf 'One or more checks failed.\n' >&2; \
 	fi; \
 	exit "$$status"
-
-clean-legacy-claude-skills-stow: ## Remove old Stow links for legacy Claude Code skills package
-	@if [ -L "$$HOME/.claude/skills" ]; then \
-		target=$$(readlink "$$HOME/.claude/skills"); \
-		case "$$target" in *packages/claude-skills/.claude/skills*) rm -f "$$HOME/.claude/skills" ;; esac; \
-	fi
-	@if [ -d "$$HOME/.claude/skills" ]; then \
-		find "$$HOME/.claude/skills" -type l -print 2>/dev/null | while IFS= read -r link; do \
-			target=$$(readlink "$$link"); \
-			case "$$target" in *packages/claude-skills/.claude/skills/*) rm -f "$$link" ;; esac; \
-		done; \
-	fi
-
-skills-install: ## Install agent skills globally via gh skill
-	gh skill install hirokisakabe/issuekit acceptance-check --agent claude-code --scope user -f
-	gh skill install hirokisakabe/issuekit cross-review --agent claude-code --scope user -f
-	gh skill install hirokisakabe/issuekit issue-create --agent claude-code --scope user -f
-	gh skill install hirokisakabe/issuekit issue-implement --agent claude-code --scope user -f
-	gh skill install hirokisakabe/issuekit issue-pick --agent claude-code --scope user -f
-	gh skill install hirokisakabe/issuekit issue-refine --agent claude-code --scope user -f
-	gh skill install hirokisakabe/issuekit worktree-start --agent claude-code --scope user -f
-	gh skill install anthropics/skills frontend-design --agent claude-code --scope user -f
-	gh skill install anthropics/skills skill-creator --agent claude-code --scope user -f
-	gh skill install vercel-labs/agent-browser agent-browser --agent claude-code --scope user -f
-
-skills-update: ## Update installed agent skills via gh skill
-	gh skill update --all
-
-setup-mcp: setup-claude-mcp setup-codex-mcp ## Setup MCP servers for AI coding agents
-
-setup-claude-mcp: ## Setup MCP servers for Claude Code
-	-claude mcp add --scope user --transport stdio chrome-devtools -- npx chrome-devtools-mcp@latest
-
-setup-codex-mcp: ## Setup MCP servers for Codex
-	-codex mcp add chrome-devtools -- npx chrome-devtools-mcp@latest
-
-promote-webfetch: ## Promote WebFetch domains from history to permissions.allow
-	./scripts/promote-webfetch.sh

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ PACKAGES := zsh vim wezterm git starship yazi bat tig lazygit claude codex copil
 	claude-permissions-promote
 
 help: ## 利用可能なタスク一覧を表示
-	@awk 'BEGIN {FS = ":.*## "} /^[a-zA-Z][a-zA-Z0-9_-]*:.*## / {names[count] = $$1; descriptions[count] = $$2; if (length($$1) > width) width = length($$1); count++} END {for (i = 0; i < count; i++) printf "\033[36m%-*s\033[0m %s\n", width + 2, names[i], descriptions[i]}' $(MAKEFILE_LIST)
+	@awk 'BEGIN {FS = ":.*## "; count = 0} /^[a-zA-Z][a-zA-Z0-9_-]*:.*## / {names[count] = $$1; descriptions[count] = $$2; if (length($$1) > width) width = length($$1); count++} END {for (i = 0; i < count; i++) printf "\033[36m%-*s\033[0m %s\n", width + 2, names[i], descriptions[i]}' $(MAKEFILE_LIST)
 
 install: ## dotfiles 環境を初回セットアップ
 	./install.sh
@@ -48,7 +48,20 @@ brewfile-dump: ## 現在の Homebrew 状態を Brewfile に書き出し
 	brew bundle dump --force --file=Brewfile
 
 brew-prune: ## Brewfile にない Homebrew パッケージを確認後に削除
-	brew bundle cleanup --file=Brewfile
+	@output=$$(brew bundle cleanup --file=Brewfile 2>&1); cleanup_status=$$?; \
+	printf '%s\n' "$$output"; \
+	if [ "$$cleanup_status" -eq 0 ]; then \
+		exit 0; \
+	fi; \
+	if ! printf '%s\n' "$$output" | grep -Fq 'Run `brew bundle cleanup --force`'; then \
+		exit "$$cleanup_status"; \
+	fi; \
+	printf '\nBrewfile にないパッケージを削除しますか? [y/N] '; \
+	read -r answer; \
+	case "$$answer" in \
+		y|Y) brew bundle cleanup --force --file=Brewfile ;; \
+		*) printf '%s\n' "削除を中止しました。" ;; \
+	esac
 
 stow-link: ## packages 配下をホームディレクトリへリンク
 	$(MAKE) _clean-legacy-claude-skills-stow
@@ -97,7 +110,10 @@ gh-extensions-update: ## インストール済みの GitHub CLI 拡張を更新
 
 gitalias-install: ## GitAlias をインストール
 	mkdir -p "$$HOME/.git-extensions"
-	curl -fsSL https://raw.githubusercontent.com/GitAlias/gitalias/main/gitalias.txt -o "$$HOME/.git-extensions/gitalias.txt"
+	@tmp_file=$$(mktemp "$$HOME/.git-extensions/gitalias.txt.XXXXXX"); \
+	trap 'rm -f "$$tmp_file"' EXIT HUP INT TERM; \
+	curl -fsSL https://raw.githubusercontent.com/GitAlias/gitalias/main/gitalias.txt -o "$$tmp_file"; \
+	mv "$$tmp_file" "$$HOME/.git-extensions/gitalias.txt"
 
 gitalias-update: gitalias-install ## GitAlias を更新
 

--- a/README.md
+++ b/README.md
@@ -5,8 +5,7 @@ macOS 向けの dotfiles リポジトリ。Homebrew でパッケージ管理、[
 ## 前提
 
 - macOS
-- [Homebrew](https://brew.sh/)
-- GNU Stow（`make install` で導入される）
+- Xcode Command Line Tools
 
 ## セットアップ
 
@@ -14,22 +13,28 @@ macOS 向けの dotfiles リポジトリ。Homebrew でパッケージ管理、[
 make install
 ```
 
-`install.sh` 経由で Homebrew のインストール、`Brewfile` のパッケージ導入、`packages/` 配下のシンボリックリンク作成、agent skill の導入までを行う。
+`install.sh` でHomebrewをbootstrapした後、Makefileの個別ターゲットを順番に実行する。Homebrewパッケージ、シンボリックリンク、mise管理ツール、agent skill、GitHub CLI拡張、GitAlias、Vimプラグイン、batテーマキャッシュをセットアップし、最後に `make doctor` で状態を検査する。
+
+MCP設定は各ツール自身の設定ファイルを更新するため、Stow管理との衝突を避けて一括セットアップから分離している。必要な場合は `make mcp-setup` を明示的に実行する。
 
 ## 主要コマンド
 
-| Command               | 用途                                                      |
-| --------------------- | --------------------------------------------------------- |
-| `make help`           | 利用可能なタスク一覧を表示                                |
-| `make install`        | 初回セットアップ（agent skill の導入を含む）              |
-| `make link`           | `packages/` 配下を `$HOME` に stow でシンボリックリンク化 |
-| `make unlink`         | stow 管理のシンボリックリンクを削除                       |
-| `make skills-install` | 管理対象の agent skill を初回導入・再導入                 |
-| `make skills-update`  | インストール済みの agent skill を最新版へ更新             |
-| `make doctor`         | dotfiles の設定状態を読み取り専用で検査                   |
-| `make update`         | `Brewfile` から Homebrew パッケージを更新                 |
-| `make sync`           | 現在の Homebrew 状態を `Brewfile` に書き戻し              |
-| `mise install`        | mise 管理の開発 CLI と Terraform をインストール           |
+| Command               | 用途                                              |
+| --------------------- | ------------------------------------------------- |
+| `make help`           | 利用可能なタスク一覧を表示                        |
+| `make install`        | dotfiles環境を一括セットアップ                    |
+| `make update`         | 管理対象のパッケージと外部リソースを一括更新      |
+| `make doctor`         | dotfilesの設定状態を読み取り専用で検査            |
+| `make brew-install`   | `Brewfile` のパッケージをインストール             |
+| `make brew-update`    | Homebrewと `Brewfile` のパッケージを更新          |
+| `make brewfile-dump`  | 現在のHomebrew状態を `Brewfile` に書き出し        |
+| `make brew-prune`     | `Brewfile` にないHomebrewパッケージを確認後に削除 |
+| `make stow-link`      | `packages/` 配下を `$HOME` にシンボリックリンク化 |
+| `make stow-unlink`    | Stow管理のシンボリックリンクを削除                |
+| `make mise-install`   | mise管理の開発CLIとTerraformをインストール        |
+| `make skills-install` | 管理対象のagent skillをインストール               |
+| `make skills-update`  | インストール済みのagent skillを更新               |
+| `make mcp-setup`      | Claude CodeとCodexのMCPサーバーを設定             |
 
 ## 詳細
 

--- a/install.sh
+++ b/install.sh
@@ -1,57 +1,31 @@
 #!/bin/bash
 
-set -e
+set -euo pipefail
 
-kernelName="$(uname -s)"
-
-if [ "$kernelName" != 'Darwin' ]; then
-  echo "Not support OS."
+if [ "$(uname -s)" != "Darwin" ]; then
+  printf '%s\n' "Unsupported OS. This setup supports macOS only." >&2
   exit 1
 fi
 
-printf '\n-- install Homebrew and formulae --\n'
-if ! command -v brew &> /dev/null; then
+if ! command -v brew >/dev/null 2>&1; then
+  printf '\n-- install Homebrew --\n'
   curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh | /bin/bash
 fi
 
-brew bundle install --cleanup --force-cleanup --file=Brewfile
-
-printf '\n-- create symbolic links with stow --\n'
-make link
-
-printf '\n-- install agent skills --\n'
-make skills-install
-
-printf '\n-- install development CLI tools with mise --\n'
-mise install
-
-printf '\n-- install gh extensions --\n'
-gh extension install dlvhdr/gh-dash || true
-gh extension install babarot/gh-infra || true
-
-printf '\n-- install GitAlias --\n'
-echo "Downloading GitAlias..."
-mkdir -p ~/.git-extensions
-curl -fsSL https://raw.githubusercontent.com/GitAlias/gitalias/main/gitalias.txt -o ~/.git-extensions/gitalias.txt
-
-# Add GitAlias include to .gitconfig if it's not already there
-if ! grep -q "\[include\]" ~/.gitconfig || ! grep -q "path = ~/.git-extensions/gitalias.txt" ~/.gitconfig; then
-  printf '\n# GitAlias configuration\n[include]\n    path = ~/.git-extensions/gitalias.txt\n' >> ~/.gitconfig
-  echo "GitAlias configured successfully!"
+if command -v brew >/dev/null 2>&1; then
+  brew_command="$(command -v brew)"
+elif [ -x /opt/homebrew/bin/brew ]; then
+  brew_command="/opt/homebrew/bin/brew"
+elif [ -x /usr/local/bin/brew ]; then
+  brew_command="/usr/local/bin/brew"
 else
-  echo "GitAlias already configured."
+  printf '%s\n' "Homebrew was installed but the brew command could not be found." >&2
+  exit 1
 fi
 
-printf '\n-- build bat theme cache (Iceberg) --\n'
-bat cache --build || true
+eval "$("$brew_command" shellenv)"
 
-printf '\n-- install vim plugins (iceberg.vim) --\n'
-ICEBERG_VIM_DIR="$HOME/.vim/pack/themes/start/iceberg.vim"
-mkdir -p "$(dirname "$ICEBERG_VIM_DIR")"
-if [ ! -d "$ICEBERG_VIM_DIR" ]; then
-  git clone --depth 1 https://github.com/cocopon/iceberg.vim.git "$ICEBERG_VIM_DIR"
-else
-  git -C "$ICEBERG_VIM_DIR" pull --ff-only || true
-fi
+printf '\n-- install dotfiles environment --\n'
+make _install
 
 printf '\n-- done! --\n'


### PR DESCRIPTION
## 概要

Makefileのターゲット命名とセットアップ責務を整理し、初回導入・更新・削除操作の境界を明確にしました。

## 変更内容

- ターゲット名を `対象-操作` 形式へ統一
- `make install` から各個別ターゲットを順番に実行
- `make update` でHomebrew、agent skill、GitHub CLI拡張、GitAlias、Vimプラグインをまとめて更新
- Homebrewの強制cleanupを初回導入から外し、確認付きの `brew-prune` へ分離
- GitAliasの取得を一時ファイル経由のatomic置換へ変更
- MCP設定をStowとの衝突回避のため明示実行へ分離
- `doctor` の検査対象と `make help` の表示を改善
- README.mdとAGENTS.mdのコマンド一覧を更新

## 影響範囲

- `Makefile`
- `install.sh`
- `README.md`
- `AGENTS.md`

## 確認内容

- `bash -n install.sh`
- `shellcheck install.sh`
- `make help`
- `make -n _install`
- `make -n update`
- `npx prettier@3 --check README.md AGENTS.md`
- 一時HOMEに対する `make stow-link` / `make stow-unlink`（残存シンボリックリンク0件）
- 独立したCodexセッションによるcross-review

`make doctor` はHomebrew、zsh、mise、GitHub CLI拡張、GitAlias、Vim、batの検査に成功しました。ローカルの `~/.codex/config.toml` が通常ファイルとして存在し、Stow対象と衝突している既存状態のみ検出しています。