### PR TITLE
fix: agent skillをClaude CodeとCodexで重複なく共有する

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -117,10 +117,11 @@ skills-install: ## 管理対象の agent skill をインストール
 			frontmatter && $$0 == "---" { \
 				closed = 1; \
 				valid_sha = length(tree_sha) == 40 && tree_sha !~ /[^0-9a-f]/; \
-				exit !(metadata_count == 1 && repo_count == 1 && path_count == 1 && sha_count == 1 && repository == expected_repository && skill_path == expected_skill_path && valid_sha); \
+				exit !(metadata_count == 1 && !invalid_metadata && repo_count == 1 && path_count == 1 && sha_count == 1 && repository == expected_repository && skill_path == expected_skill_path && valid_sha); \
 			} \
 			frontmatter && $$0 == "metadata:" { metadata = 1; metadata_count++; next } \
 			metadata && /^[^[:space:]]/ { metadata = 0 } \
+			metadata && /^  [^ ]/ { invalid_metadata = 1; metadata = 0 } \
 			metadata && /^    github-repo:[[:space:]]*/ { repo_count++; repository = $$0; sub(/^    github-repo:[[:space:]]*/, "", repository); next } \
 			metadata && /^    github-path:[[:space:]]*/ { path_count++; skill_path = $$0; sub(/^    github-path:[[:space:]]*/, "", skill_path); next } \
 			metadata && /^    github-tree-sha:[[:space:]]*/ { sha_count++; tree_sha = $$0; sub(/^    github-tree-sha:[[:space:]]*/, "", tree_sha); next } \

--- a/Makefile
+++ b/Makefile
@@ -106,37 +106,63 @@ mise-install: ## mise 管理の開発ツールをインストール
 
 skills-install: ## 管理対象の agent skill をインストール
 	@mkdir -p "$(AGENT_SKILLS_DIR)" "$(CLAUDE_SKILLS_DIR)"
-	@set -e; for skill_spec in $(AGENT_SKILLS); do \
+	@set -e; \
+	is_managed_skill() { \
+		skill_file_path="$$1/SKILL.md"; \
+		expected_repository="https://github.com/$$2"; \
+		[ -f "$$skill_file_path" ] || return 1; \
+		metadata_repository=$$(sed -n 's/^[[:space:]]*github-repo:[[:space:]]*//p' "$$skill_file_path" | head -n 1); \
+		[ "$$metadata_repository" = "$$expected_repository" ]; \
+	}; \
+	for skill_spec in $(AGENT_SKILLS); do \
 		repository=$${skill_spec%:*}; \
 		skill=$${skill_spec#*:}; \
-		gh skill install "$$repository" "$$skill" --dir "$(AGENT_SKILLS_DIR)" -f; \
 		canonical_path="$(AGENT_SKILLS_DIR)/$$skill"; \
 		claude_path="$(CLAUDE_SKILLS_DIR)/$$skill"; \
 		codex_path="$(CODEX_SKILLS_DIR)/$$skill"; \
+		if [ -L "$$canonical_path" ]; then \
+			if is_managed_skill "$$canonical_path" "$$repository"; then \
+				rm -f "$$canonical_path"; \
+			else \
+				printf '%s\n' "管理外の symlink と競合しています: $$canonical_path" >&2; \
+				exit 1; \
+			fi; \
+		fi; \
+		gh skill install "$$repository" "$$skill" --dir "$(AGENT_SKILLS_DIR)" -f; \
 		if [ -L "$$claude_path" ]; then \
 			target=$$(readlink "$$claude_path"); \
-			if [ "$$target" = "$$canonical_path" ]; then \
+			if [ "$$claude_path" -ef "$$canonical_path" ]; then \
 				:; \
 			elif [ ! -e "$$claude_path" ]; then \
+				rm -f "$$claude_path"; \
+			elif is_managed_skill "$$claude_path" "$$repository"; then \
 				rm -f "$$claude_path"; \
 			else \
 				printf '%s\n' "既存の外部 symlink を保持します: $$claude_path -> $$target"; \
 			fi; \
 		elif [ -e "$$claude_path" ]; then \
-			rm -rf "$$claude_path"; \
+			if is_managed_skill "$$claude_path" "$$repository"; then \
+				rm -rf "$$claude_path"; \
+			else \
+				printf '%s\n' "管理外の既存 skill を保持します: $$claude_path"; \
+			fi; \
 		fi; \
 		if [ ! -e "$$claude_path" ] && [ ! -L "$$claude_path" ]; then \
 			ln -s "$$canonical_path" "$$claude_path"; \
 		fi; \
 		if [ -L "$$codex_path" ]; then \
 			target=$$(readlink "$$codex_path"); \
-			if [ "$$target" = "$$canonical_path" ] || [ ! -e "$$codex_path" ]; then \
+			if [ ! -e "$$codex_path" ] || [ "$$codex_path" -ef "$$canonical_path" ] || is_managed_skill "$$codex_path" "$$repository"; then \
 				rm -f "$$codex_path"; \
 			else \
 				printf '%s\n' "既存の外部 symlink を保持します: $$codex_path -> $$target"; \
 			fi; \
 		elif [ -e "$$codex_path" ]; then \
-			rm -rf "$$codex_path"; \
+			if is_managed_skill "$$codex_path" "$$repository"; then \
+				rm -rf "$$codex_path"; \
+			else \
+				printf '%s\n' "管理外の既存 skill を保持します: $$codex_path"; \
+			fi; \
 		fi; \
 	done
 

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,24 @@
 
 PACKAGES := zsh vim wezterm git starship yazi bat tig lazygit claude codex copilot worktrunk gh-dash mise pnpm atuin
 
+AGENT_SKILLS := \
+	hirokisakabe/issuekit:acceptance-check \
+	hirokisakabe/issuekit:cross-review \
+	hirokisakabe/issuekit:issue-create \
+	hirokisakabe/issuekit:issue-dispatch \
+	hirokisakabe/issuekit:issue-implement \
+	hirokisakabe/issuekit:issue-investigate \
+	hirokisakabe/issuekit:issue-pick \
+	hirokisakabe/issuekit:issue-refine \
+	hirokisakabe/issuekit:worktree-start \
+	anthropics/skills:frontend-design \
+	anthropics/skills:skill-creator \
+	vercel-labs/agent-browser:agent-browser
+
+AGENT_SKILLS_DIR ?= $(HOME)/.agents/skills
+CLAUDE_SKILLS_DIR ?= $(HOME)/.claude/skills
+CODEX_SKILLS_DIR ?= $(HOME)/.codex/skills
+
 .PHONY: help install _install update doctor \
 	brew-install brew-update brewfile-dump brew-prune \
 	stow-link stow-unlink _clean-legacy-claude-skills-stow \
@@ -87,21 +105,43 @@ mise-install: ## mise 管理の開発ツールをインストール
 	mise install
 
 skills-install: ## 管理対象の agent skill をインストール
-	gh skill install hirokisakabe/issuekit acceptance-check --agent claude-code --scope user -f
-	gh skill install hirokisakabe/issuekit cross-review --agent claude-code --scope user -f
-	gh skill install hirokisakabe/issuekit issue-create --agent claude-code --scope user -f
-	gh skill install hirokisakabe/issuekit issue-dispatch --agent claude-code --scope user -f
-	gh skill install hirokisakabe/issuekit issue-implement --agent claude-code --scope user -f
-	gh skill install hirokisakabe/issuekit issue-investigate --agent claude-code --scope user -f
-	gh skill install hirokisakabe/issuekit issue-pick --agent claude-code --scope user -f
-	gh skill install hirokisakabe/issuekit issue-refine --agent claude-code --scope user -f
-	gh skill install hirokisakabe/issuekit worktree-start --agent claude-code --scope user -f
-	gh skill install anthropics/skills frontend-design --agent claude-code --scope user -f
-	gh skill install anthropics/skills skill-creator --agent claude-code --scope user -f
-	gh skill install vercel-labs/agent-browser agent-browser --agent claude-code --scope user -f
+	@mkdir -p "$(AGENT_SKILLS_DIR)" "$(CLAUDE_SKILLS_DIR)"
+	@set -e; for skill_spec in $(AGENT_SKILLS); do \
+		repository=$${skill_spec%:*}; \
+		skill=$${skill_spec#*:}; \
+		gh skill install "$$repository" "$$skill" --dir "$(AGENT_SKILLS_DIR)" -f; \
+		canonical_path="$(AGENT_SKILLS_DIR)/$$skill"; \
+		claude_path="$(CLAUDE_SKILLS_DIR)/$$skill"; \
+		codex_path="$(CODEX_SKILLS_DIR)/$$skill"; \
+		if [ -L "$$claude_path" ]; then \
+			target=$$(readlink "$$claude_path"); \
+			if [ "$$target" = "$$canonical_path" ]; then \
+				:; \
+			elif [ ! -e "$$claude_path" ]; then \
+				rm -f "$$claude_path"; \
+			else \
+				printf '%s\n' "既存の外部 symlink を保持します: $$claude_path -> $$target"; \
+			fi; \
+		elif [ -e "$$claude_path" ]; then \
+			rm -rf "$$claude_path"; \
+		fi; \
+		if [ ! -e "$$claude_path" ] && [ ! -L "$$claude_path" ]; then \
+			ln -s "$$canonical_path" "$$claude_path"; \
+		fi; \
+		if [ -L "$$codex_path" ]; then \
+			target=$$(readlink "$$codex_path"); \
+			if [ "$$target" = "$$canonical_path" ] || [ ! -e "$$codex_path" ]; then \
+				rm -f "$$codex_path"; \
+			else \
+				printf '%s\n' "既存の外部 symlink を保持します: $$codex_path -> $$target"; \
+			fi; \
+		elif [ -e "$$codex_path" ]; then \
+			rm -rf "$$codex_path"; \
+		fi; \
+	done
 
 skills-update: ## インストール済みの agent skill を更新
-	gh skill update --all
+	gh skill update --all --dir "$(AGENT_SKILLS_DIR)"
 
 gh-extensions-install: ## 管理対象の GitHub CLI 拡張をインストール
 	gh extension install dlvhdr/gh-dash --force

--- a/Makefile
+++ b/Makefile
@@ -110,9 +110,14 @@ skills-install: ## 管理対象の agent skill をインストール
 	is_managed_skill() { \
 		skill_file_path="$$1/SKILL.md"; \
 		expected_repository="https://github.com/$$2"; \
+		expected_skill="$$3"; \
 		[ -f "$$skill_file_path" ] || return 1; \
-		metadata_repository=$$(sed -n 's/^[[:space:]]*github-repo:[[:space:]]*//p' "$$skill_file_path" | head -n 1); \
-		[ "$$metadata_repository" = "$$expected_repository" ]; \
+		metadata_repository=$$(awk 'NR == 1 && $$0 == "---" { frontmatter = 1; next } frontmatter && $$0 == "---" { exit } frontmatter && /^[[:space:]]*github-repo:/ { sub(/^[[:space:]]*github-repo:[[:space:]]*/, ""); print; exit }' "$$skill_file_path"); \
+		metadata_path=$$(awk 'NR == 1 && $$0 == "---" { frontmatter = 1; next } frontmatter && $$0 == "---" { exit } frontmatter && /^[[:space:]]*github-path:/ { sub(/^[[:space:]]*github-path:[[:space:]]*/, ""); print; exit }' "$$skill_file_path"); \
+		metadata_tree_sha=$$(awk 'NR == 1 && $$0 == "---" { frontmatter = 1; next } frontmatter && $$0 == "---" { exit } frontmatter && /^[[:space:]]*github-tree-sha:/ { sub(/^[[:space:]]*github-tree-sha:[[:space:]]*/, ""); print; exit }' "$$skill_file_path"); \
+		[ "$$metadata_repository" = "$$expected_repository" ] && \
+			[ "$${metadata_path##*/}" = "$$expected_skill" ] && \
+			[ -n "$$metadata_tree_sha" ]; \
 	}; \
 	for skill_spec in $(AGENT_SKILLS); do \
 		repository=$${skill_spec%:*}; \
@@ -121,12 +126,15 @@ skills-install: ## 管理対象の agent skill をインストール
 		claude_path="$(CLAUDE_SKILLS_DIR)/$$skill"; \
 		codex_path="$(CODEX_SKILLS_DIR)/$$skill"; \
 		if [ -L "$$canonical_path" ]; then \
-			if is_managed_skill "$$canonical_path" "$$repository"; then \
+			if is_managed_skill "$$canonical_path" "$$repository" "$$skill"; then \
 				rm -f "$$canonical_path"; \
 			else \
 				printf '%s\n' "管理外の symlink と競合しています: $$canonical_path" >&2; \
 				exit 1; \
 			fi; \
+		elif [ -e "$$canonical_path" ] && ! is_managed_skill "$$canonical_path" "$$repository" "$$skill"; then \
+			printf '%s\n' "管理外の既存 skill と競合しています: $$canonical_path" >&2; \
+			exit 1; \
 		fi; \
 		gh skill install "$$repository" "$$skill" --dir "$(AGENT_SKILLS_DIR)" -f; \
 		if [ -L "$$claude_path" ]; then \
@@ -134,31 +142,36 @@ skills-install: ## 管理対象の agent skill をインストール
 			if [ "$$claude_path" -ef "$$canonical_path" ]; then \
 				:; \
 			elif [ ! -e "$$claude_path" ]; then \
-				rm -f "$$claude_path"; \
-			elif is_managed_skill "$$claude_path" "$$repository"; then \
+				printf '%s\n' "既存の壊れた外部 symlink を保持します: $$claude_path -> $$target"; \
+			elif is_managed_skill "$$claude_path" "$$repository" "$$skill"; then \
 				rm -f "$$claude_path"; \
 			else \
 				printf '%s\n' "既存の外部 symlink を保持します: $$claude_path -> $$target"; \
 			fi; \
 		elif [ -e "$$claude_path" ]; then \
-			if is_managed_skill "$$claude_path" "$$repository"; then \
+			if is_managed_skill "$$claude_path" "$$repository" "$$skill"; then \
 				rm -rf "$$claude_path"; \
 			else \
 				printf '%s\n' "管理外の既存 skill を保持します: $$claude_path"; \
 			fi; \
 		fi; \
 		if [ ! -e "$$claude_path" ] && [ ! -L "$$claude_path" ]; then \
-			ln -s "$$canonical_path" "$$claude_path"; \
+			if [ "$(AGENT_SKILLS_DIR)" = "$(HOME)/.agents/skills" ] && [ "$(CLAUDE_SKILLS_DIR)" = "$(HOME)/.claude/skills" ]; then \
+				link_target="../../.agents/skills/$$skill"; \
+			else \
+				link_target="$$canonical_path"; \
+			fi; \
+			ln -s "$$link_target" "$$claude_path"; \
 		fi; \
 		if [ -L "$$codex_path" ]; then \
 			target=$$(readlink "$$codex_path"); \
-			if [ ! -e "$$codex_path" ] || [ "$$codex_path" -ef "$$canonical_path" ] || is_managed_skill "$$codex_path" "$$repository"; then \
+			if [ -e "$$codex_path" ] && { [ "$$codex_path" -ef "$$canonical_path" ] || is_managed_skill "$$codex_path" "$$repository" "$$skill"; }; then \
 				rm -f "$$codex_path"; \
 			else \
 				printf '%s\n' "既存の外部 symlink を保持します: $$codex_path -> $$target"; \
 			fi; \
 		elif [ -e "$$codex_path" ]; then \
-			if is_managed_skill "$$codex_path" "$$repository"; then \
+			if is_managed_skill "$$codex_path" "$$repository" "$$skill"; then \
 				rm -rf "$$codex_path"; \
 			else \
 				printf '%s\n' "管理外の既存 skill を保持します: $$codex_path"; \

--- a/Makefile
+++ b/Makefile
@@ -110,14 +110,22 @@ skills-install: ## 管理対象の agent skill をインストール
 	is_managed_skill() { \
 		skill_file_path="$$1/SKILL.md"; \
 		expected_repository="https://github.com/$$2"; \
-		expected_skill="$$3"; \
+		expected_skill_path="skills/$$3"; \
 		[ -f "$$skill_file_path" ] || return 1; \
-		metadata_repository=$$(awk 'NR == 1 && $$0 == "---" { frontmatter = 1; next } frontmatter && $$0 == "---" { exit } frontmatter && /^[[:space:]]*github-repo:/ { sub(/^[[:space:]]*github-repo:[[:space:]]*/, ""); print; exit }' "$$skill_file_path"); \
-		metadata_path=$$(awk 'NR == 1 && $$0 == "---" { frontmatter = 1; next } frontmatter && $$0 == "---" { exit } frontmatter && /^[[:space:]]*github-path:/ { sub(/^[[:space:]]*github-path:[[:space:]]*/, ""); print; exit }' "$$skill_file_path"); \
-		metadata_tree_sha=$$(awk 'NR == 1 && $$0 == "---" { frontmatter = 1; next } frontmatter && $$0 == "---" { exit } frontmatter && /^[[:space:]]*github-tree-sha:/ { sub(/^[[:space:]]*github-tree-sha:[[:space:]]*/, ""); print; exit }' "$$skill_file_path"); \
-		[ "$$metadata_repository" = "$$expected_repository" ] && \
-			[ "$${metadata_path##*/}" = "$$expected_skill" ] && \
-			[ -n "$$metadata_tree_sha" ]; \
+		awk -v expected_repository="$$expected_repository" -v expected_skill_path="$$expected_skill_path" ' \
+			NR == 1 { if ($$0 != "---") exit 1; frontmatter = 1; next } \
+			frontmatter && $$0 == "---" { \
+				closed = 1; \
+				valid_sha = length(tree_sha) == 40 && tree_sha !~ /[^0-9a-f]/; \
+				exit !(metadata_count == 1 && repo_count == 1 && path_count == 1 && sha_count == 1 && repository == expected_repository && skill_path == expected_skill_path && valid_sha); \
+			} \
+			frontmatter && $$0 == "metadata:" { metadata = 1; metadata_count++; next } \
+			metadata && /^[^[:space:]]/ { metadata = 0 } \
+			metadata && /^    github-repo:[[:space:]]*/ { repo_count++; repository = $$0; sub(/^    github-repo:[[:space:]]*/, "", repository); next } \
+			metadata && /^    github-path:[[:space:]]*/ { path_count++; skill_path = $$0; sub(/^    github-path:[[:space:]]*/, "", skill_path); next } \
+			metadata && /^    github-tree-sha:[[:space:]]*/ { sha_count++; tree_sha = $$0; sub(/^    github-tree-sha:[[:space:]]*/, "", tree_sha); next } \
+			END { if (!closed) exit 1 } \
+		' "$$skill_file_path" >/dev/null; \
 	}; \
 	for skill_spec in $(AGENT_SKILLS); do \
 		repository=$${skill_spec%:*}; \

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ MCP設定は各ツール自身の設定ファイルを更新するため、Stow�
 
 ### Agent skill
 
-`make skills-install` は管理対象のagent skillを `~/.agents/skills/<name>` に一度だけインストールする。Codexはこの共通ディレクトリから直接読み込み、Claude Codeは `~/.claude/skills/<name>` から正本へのsymlinkを介して同じskillを利用する。これにより、両方のskill selectorに同名skillが重複して表示されない。
+`make skills-install` は管理対象のagent skillを単一の正本として `~/.agents/skills/<name>` にインストールする。Codexはこの共通ディレクトリから直接読み込み、Claude Codeは `~/.claude/skills/<name>` から正本へのsymlinkを介して同じskillを利用する。これにより、両方のskill selectorに同名skillが重複して表示されない。
 
 `make skills-update` は `~/.agents/skills` を明示して、共通配置されたskillを更新する。
 

--- a/README.md
+++ b/README.md
@@ -17,6 +17,12 @@ make install
 
 MCP設定は各ツール自身の設定ファイルを更新するため、Stow管理との衝突を避けて一括セットアップから分離している。必要な場合は `make mcp-setup` を明示的に実行する。
 
+### Agent skill
+
+`make skills-install` は管理対象のagent skillを `~/.agents/skills/<name>` に一度だけインストールする。Codexはこの共通ディレクトリから直接読み込み、Claude Codeは `~/.claude/skills/<name>` から正本へのsymlinkを介して同じskillを利用する。これにより、両方のskill selectorに同名skillが重複して表示されない。
+
+`make skills-update` は `~/.agents/skills` を明示して、共通配置されたskillを更新する。
+
 ## 主要コマンド
 
 | Command               | 用途                                              |


### PR DESCRIPTION
close #378

## 概要

管理対象のagent skillを `~/.agents/skills` に正本として集約し、Claude Codeからは `~/.claude/skills` のsymlink経由で同じskillを利用するようにしました。Codex側の管理対象重複を安全に移行し、管理外のskill・外部symlink・system skillは保持します。

## 変更内容

- `Makefile`
  - 管理対象skillと取得元を `AGENT_SKILLS` に集約
  - `gh skill install --dir ~/.agents/skills` で正本を共通配置
  - Claude Code向けの互換symlinkを作成
  - GitHub source metadataを厳密に検証し、管理対象と確認できた旧配置だけを移行
  - `skills-update` の更新対象を共通配置へ明示
- `README.md`
  - 正本の配置先とClaude Code/Codex間の共有方法を追記

## 検証

- 新規の一時環境で管理対象12件が `~/.agents/skills` に導入され、Claude用symlinkが作成されることを確認
- 既存ディレクトリ、相対symlink、外部symlink、dangling symlink、Codex重複、`.system`、管理外skillの移行fixtureを確認
- spoofed / nested metadataを管理対象と誤認せず保持することを確認
- `make skills-update`（一時環境）
- `make -n skills-install | /bin/sh -n`
- `make help`
- `npx prettier@3 --check .`
- cross-review: critical 0 / warning 0