### PR TITLE
codex: global AGENTS.md から重複した Git ワークフロー規則を削除する

### DIFF
--- a/packages/codex/.codex/AGENTS.md
+++ b/packages/codex/.codex/AGENTS.md
@@ -1,10 +1,5 @@
 # AI Agent Configuration
 
-## Git ワークフロー
-
-- PR の description は日本語で記載する
-- ユーザーから明示的に issue 番号を指定された場合のみ、PR description の先頭に `close #<issue番号>` を記載する
-
 ## 最新情報の参照
 
 - バージョン・仕様・状況が変わりうる技術トピックは、知識ベースで答えず WebSearch / WebFetch で必ず確認する。


### PR DESCRIPTION
close #380

## 概要

Codex の global `AGENTS.md` から重複していた `Git ワークフロー` セクションを削除し、PR description と issue close に関する運用ルールを issuekit の skill 側へ一本化します。

## 変更内容

- `packages/codex/.codex/AGENTS.md` から `Git ワークフロー` セクションを削除
- `最新情報の参照` セクションおよび Stow 管理上の配置は維持

## 影響範囲

- `packages/codex/.codex/AGENTS.md` のみ

## 確認内容

- `npx prettier@3 --check .`
- `git diff --check`
- Stow dry-run
- 受け入れ条件 4 件すべて充足
- 独立した Codex reviewer session による cross-review（critical 0 / warning 0 / info 0）
