### PR TITLE
feat: Codex の共有設定を system config に分離

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,7 +10,8 @@ macOS 向けの dotfiles リポジトリ。Homebrew でパッケージ管理、G
 
 - `packages/`: one directory per tool (`zsh`, `vim`, `wezterm`, `git`, `codex`, etc.).
 - `packages/*/`: mirrored home-directory layout (for example, `packages/yazi/.config/yazi/`).
-- `packages/codex/`: contains `AGENTS.md`, Codex CLI の指示ファイル。
+- `packages/codex/`: contains Stow-managed `AGENTS.md` and `rules/default.rules`。
+- `config/codex/config.toml`: `/etc/codex/config.toml` へ導入する共有Codex設定の正本。
 - `Makefile`: primary task entrypoint for setup, linking, and package maintenance.
 - `install.sh`: bootstrap script used by `make install`.
 - `Brewfile` / `Brewfile.lock.json`: Homebrew package definitions and lock data.
@@ -25,7 +26,8 @@ packages/           # Stow パッケージ（各ツールの設定ファイル�
 ├── starship/      # .config/starship.toml
 ├── yazi/          # .config/yazi/yazi.toml
 ├── claude/        # .claude/settings.json, .claude/CLAUDE.md
-└── codex/         # .codex/AGENTS.md, config.toml, rules/default.rules
+└── codex/         # .codex/AGENTS.md, rules/default.rules
+config/codex/      # /etc/codex/config.toml の共有設定正本
 ```
 
 ### Stow の仕組み

--- a/Makefile
+++ b/Makefile
@@ -265,24 +265,52 @@ codex-system-config-install: codex-system-config-dry-run ## 共有Codex設定を
 	umask 077; \
 	source="$(CODEX_SHARED_CONFIG)"; \
 	destination="$(CODEX_SYSTEM_CONFIG)"; \
+	destination_dir=$$(dirname "$$destination"); \
+	tmp_file=''; \
+	cleanup() { \
+		if [ -n "$$tmp_file" ]; then \
+			$(CODEX_CONFIG_SUDO) rm -f "$$tmp_file"; \
+		fi; \
+	}; \
+	trap cleanup 0 1 2 15; \
+	if $(CODEX_CONFIG_SUDO) test -L "$$destination"; then \
+		printf '%s\n' "symlink は自動処理しません: $$destination" >&2; \
+		exit 1; \
+	fi; \
 	if $(CODEX_CONFIG_SUDO) test -e "$$destination"; then \
-		tmp_file=$$(mktemp); \
-		trap 'rm -f "$$tmp_file"' 0 1 2 15; \
-		$(CODEX_CONFIG_SUDO) cat "$$destination" >"$$tmp_file"; \
-		if cmp -s "$$tmp_file" "$$source"; then \
-			rm -f "$$tmp_file"; \
-			trap - 0 1 2 15; \
+		current_file=$$(mktemp); \
+		trap 'rm -f "$$current_file"; cleanup' 0 1 2 15; \
+		$(CODEX_CONFIG_SUDO) cat "$$destination" >"$$current_file"; \
+		if cmp -s "$$current_file" "$$source"; then \
+			rm -f "$$current_file"; \
+			trap cleanup 0 1 2 15; \
 			printf '%s\n' "既に最新です: $$destination"; \
 			exit 0; \
 		fi; \
-		rm -f "$$tmp_file"; \
-		trap - 0 1 2 15; \
+		rm -f "$$current_file"; \
+		trap cleanup 0 1 2 15; \
 		printf '既存の %s を上記内容で更新しますか? [y/N] ' "$$destination"; \
 		read -r answer; \
 		case "$$answer" in y|Y) ;; *) printf '%s\n' '更新を中止しました。'; exit 1 ;; esac; \
 	fi; \
-	$(CODEX_CONFIG_SUDO) install -d -m 0755 "$$(dirname "$$destination")"; \
-	$(CODEX_CONFIG_SUDO) install -m 0644 "$$source" "$$destination"; \
+	$(CODEX_CONFIG_SUDO) install -d -m 0755 "$$destination_dir"; \
+	if $(CODEX_CONFIG_SUDO) test -L "$$destination"; then \
+		printf '%s\n' "symlink は自動処理しません: $$destination" >&2; \
+		exit 1; \
+	fi; \
+	tmp_file=$$($(CODEX_CONFIG_SUDO) mktemp "$$destination_dir/.config.toml.install.XXXXXX"); \
+	$(CODEX_CONFIG_SUDO) install -m 0644 "$$source" "$$tmp_file"; \
+	if $(CODEX_CONFIG_SUDO) test -L "$$tmp_file" || ! $(CODEX_CONFIG_SUDO) test -f "$$tmp_file"; then \
+		printf '%s\n' "一時ファイルが通常ファイルではありません: $$tmp_file" >&2; \
+		exit 1; \
+	fi; \
+	if $(CODEX_CONFIG_SUDO) test -L "$$destination"; then \
+		printf '%s\n' "symlink は自動処理しません: $$destination" >&2; \
+		exit 1; \
+	fi; \
+	$(CODEX_CONFIG_SUDO) mv -fh "$$tmp_file" "$$destination"; \
+	tmp_file=''; \
+	trap - 0 1 2 15; \
 	printf '%s\n' "導入しました: $$destination"
 
 codex-system-config-check: ## 共有Codex設定を一時CODEX_HOMEで非破壊検証

--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,6 @@ AGENT_SKILLS_DIR ?= $(HOME)/.agents/skills
 CLAUDE_SKILLS_DIR ?= $(HOME)/.claude/skills
 CODEX_SKILLS_DIR ?= $(HOME)/.codex/skills
 CODEX_SHARED_CONFIG := config/codex/config.toml
-CODEX_USER_CONFIG ?= $(HOME)/.codex/config.toml
 CODEX_SYSTEM_CONFIG ?= /etc/codex/config.toml
 CODEX_CONFIG_SUDO ?= sudo
 
@@ -32,7 +31,7 @@ CODEX_CONFIG_SUDO ?= sudo
 	gitalias-install gitalias-update \
 	vim-plugins-install vim-plugins-update bat-cache-build \
 	mcp-setup claude-mcp-setup codex-mcp-setup \
-	claude-permissions-promote codex-user-config-migrate \
+	claude-permissions-promote \
 	codex-system-config-dry-run codex-system-config-install \
 	codex-system-config-check codex-system-config-verify
 
@@ -87,7 +86,7 @@ brew-prune: ## Brewfile にない Homebrew パッケージを確認後に削除
 		*) printf '%s\n' "削除を中止しました。" ;; \
 	esac
 
-stow-link: codex-user-config-migrate ## packages 配下をホームディレクトリへリンク
+stow-link: ## packages 配下をホームディレクトリへリンク
 	$(MAKE) _clean-legacy-claude-skills-stow
 	cd packages && stow -v --no-folding -t "$$HOME" $(PACKAGES)
 
@@ -234,61 +233,6 @@ claude-mcp-setup: ## Claude Code の MCP サーバーを設定
 codex-mcp-setup: ## Codex の MCP サーバーを設定
 	@codex mcp get chrome-devtools >/dev/null 2>&1 || \
 		codex mcp add chrome-devtools -- npx chrome-devtools-mcp@latest
-
-codex-user-config-migrate: ## 旧Stow symlinkを内容を保持した通常ファイルへ移行
-	@set -eu; \
-	user_config="$(CODEX_USER_CONFIG)"; \
-	legacy_path='packages/codex/.codex/config.toml'; \
-	if [ ! -L "$$user_config" ]; then \
-		exit 0; \
-	fi; \
-	link_target=$$(readlink "$$user_config"); \
-	case "$$link_target" in \
-		/*) target_path="$$link_target" ;; \
-		*) target_dir=$$(cd "$$(dirname "$$user_config")/$$(dirname "$$link_target")" 2>/dev/null && pwd -P) || { \
-			printf '%s\n' "管理元を確認できない symlink を保持します: $$user_config -> $$link_target" >&2; \
-			exit 1; \
-		}; \
-		target_path="$$target_dir/$$(basename "$$link_target")" ;; \
-	esac; \
-	target_repo=$$(git -C "$$(dirname "$$target_path")" rev-parse --show-toplevel 2>/dev/null) || { \
-		printf '%s\n' "管理外の symlink を保持します: $$user_config -> $$link_target" >&2; \
-		exit 1; \
-	}; \
-	current_common_dir=$$(git rev-parse --path-format=absolute --git-common-dir); \
-	target_common_dir=$$(git -C "$$target_repo" rev-parse --path-format=absolute --git-common-dir); \
-	current_origin=$$(git config --get remote.origin.url 2>/dev/null || true); \
-	target_origin=$$(git -C "$$target_repo" config --get remote.origin.url 2>/dev/null || true); \
-	normalize_origin() { printf '%s\n' "$$1" | sed -E 's#^git@github.com:#https://github.com/#; s#^ssh://git@github.com/#https://github.com/#; s#\.git$$##'; }; \
-	current_origin=$$(normalize_origin "$$current_origin"); \
-	target_origin=$$(normalize_origin "$$target_origin"); \
-	if [ "$$target_path" != "$$target_repo/$$legacy_path" ] || { \
-		[ "$$target_common_dir" != "$$current_common_dir" ] && { \
-			[ -z "$$current_origin" ] || [ "$$target_origin" != "$$current_origin" ]; \
-		}; \
-	}; then \
-		printf '%s\n' "管理外の symlink を保持します: $$user_config -> $$link_target" >&2; \
-		exit 1; \
-	fi; \
-	tmp_file=$$(mktemp "$$(dirname "$$user_config")/.config.toml.migrate.XXXXXX"); \
-	trap 'rm -f "$$tmp_file"' 0 1 2 15; \
-	if [ -f "$$user_config" ]; then \
-		cp -p "$$user_config" "$$tmp_file"; \
-	else \
-		legacy_commit=$$(for commit in $$(git -C "$$target_repo" log --format=%H --all -- "$$legacy_path"); do \
-			if git -C "$$target_repo" cat-file -e "$$commit:$$legacy_path" 2>/dev/null; then \
-				printf '%s\n' "$$commit"; \
-				break; \
-			fi; \
-		done); \
-		if [ -z "$$legacy_commit" ] || ! git -C "$$target_repo" show "$$legacy_commit:$$legacy_path" >"$$tmp_file"; then \
-			printf '%s\n' "旧 user config の内容を復元できません: $$user_config" >&2; \
-			exit 1; \
-		fi; \
-	fi; \
-	mv -f "$$tmp_file" "$$user_config"; \
-	trap - 0 1 2 15; \
-	printf '%s\n' "通常ファイルへ移行しました: $$user_config"
 
 codex-system-config-dry-run: ## system configの適用内容または差分を表示
 	@set -eu; \

--- a/Makefile
+++ b/Makefile
@@ -292,6 +292,7 @@ codex-user-config-migrate: ## 旧Stow symlinkを内容を保持した通常フ�
 
 codex-system-config-dry-run: ## system configの適用内容または差分を表示
 	@set -eu; \
+	umask 077; \
 	source="$(CODEX_SHARED_CONFIG)"; \
 	destination="$(CODEX_SYSTEM_CONFIG)"; \
 	if $(CODEX_CONFIG_SUDO) test -L "$$destination"; then \
@@ -300,6 +301,7 @@ codex-system-config-dry-run: ## system configの適用内容または差分を�
 	fi; \
 	if $(CODEX_CONFIG_SUDO) test -e "$$destination"; then \
 		tmp_file=$$(mktemp); \
+		trap 'rm -f "$$tmp_file"' 0 1 2 15; \
 		$(CODEX_CONFIG_SUDO) cat "$$destination" >"$$tmp_file"; \
 		if cmp -s "$$tmp_file" "$$source"; then \
 			printf '%s\n' "変更はありません: $$destination"; \
@@ -308,6 +310,7 @@ codex-system-config-dry-run: ## system configの適用内容または差分を�
 			diff -u "$$tmp_file" "$$source" || true; \
 		fi; \
 		rm -f "$$tmp_file"; \
+		trap - 0 1 2 15; \
 	else \
 		printf '%s\n' "新規作成予定: $$destination"; \
 		sed -n '1,$$p' "$$source"; \
@@ -315,17 +318,21 @@ codex-system-config-dry-run: ## system configの適用内容または差分を�
 
 codex-system-config-install: codex-system-config-dry-run ## 共有Codex設定をsystem configへ導入・更新
 	@set -eu; \
+	umask 077; \
 	source="$(CODEX_SHARED_CONFIG)"; \
 	destination="$(CODEX_SYSTEM_CONFIG)"; \
 	if $(CODEX_CONFIG_SUDO) test -e "$$destination"; then \
 		tmp_file=$$(mktemp); \
+		trap 'rm -f "$$tmp_file"' 0 1 2 15; \
 		$(CODEX_CONFIG_SUDO) cat "$$destination" >"$$tmp_file"; \
 		if cmp -s "$$tmp_file" "$$source"; then \
 			rm -f "$$tmp_file"; \
+			trap - 0 1 2 15; \
 			printf '%s\n' "既に最新です: $$destination"; \
 			exit 0; \
 		fi; \
 		rm -f "$$tmp_file"; \
+		trap - 0 1 2 15; \
 		printf '既存の %s を上記内容で更新しますか? [y/N] ' "$$destination"; \
 		read -r answer; \
 		case "$$answer" in y|Y) ;; *) printf '%s\n' '更新を中止しました。'; exit 1 ;; esac; \

--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,10 @@ AGENT_SKILLS := \
 AGENT_SKILLS_DIR ?= $(HOME)/.agents/skills
 CLAUDE_SKILLS_DIR ?= $(HOME)/.claude/skills
 CODEX_SKILLS_DIR ?= $(HOME)/.codex/skills
+CODEX_SHARED_CONFIG := config/codex/config.toml
+CODEX_USER_CONFIG ?= $(HOME)/.codex/config.toml
+CODEX_SYSTEM_CONFIG ?= /etc/codex/config.toml
+CODEX_CONFIG_SUDO ?= sudo
 
 .PHONY: help install _install update doctor \
 	brew-install brew-update brewfile-dump brew-prune \
@@ -28,7 +32,9 @@ CODEX_SKILLS_DIR ?= $(HOME)/.codex/skills
 	gitalias-install gitalias-update \
 	vim-plugins-install vim-plugins-update bat-cache-build \
 	mcp-setup claude-mcp-setup codex-mcp-setup \
-	claude-permissions-promote
+	claude-permissions-promote codex-user-config-migrate \
+	codex-system-config-dry-run codex-system-config-install \
+	codex-system-config-check codex-system-config-verify
 
 help: ## 利用可能なタスク一覧を表示
 	@awk 'BEGIN {FS = ":.*## "; count = 0} /^[a-zA-Z][a-zA-Z0-9_-]*:.*## / {names[count] = $$1; descriptions[count] = $$2; if (length($$1) > width) width = length($$1); count++} END {for (i = 0; i < count; i++) printf "\033[36m%-*s\033[0m %s\n", width + 2, names[i], descriptions[i]}' $(MAKEFILE_LIST)
@@ -81,7 +87,7 @@ brew-prune: ## Brewfile にない Homebrew パッケージを確認後に削除
 		*) printf '%s\n' "削除を中止しました。" ;; \
 	esac
 
-stow-link: ## packages 配下をホームディレクトリへリンク
+stow-link: codex-user-config-migrate ## packages 配下をホームディレクトリへリンク
 	$(MAKE) _clean-legacy-claude-skills-stow
 	cd packages && stow -v --no-folding -t "$$HOME" $(PACKAGES)
 
@@ -228,6 +234,123 @@ claude-mcp-setup: ## Claude Code の MCP サーバーを設定
 codex-mcp-setup: ## Codex の MCP サーバーを設定
 	@codex mcp get chrome-devtools >/dev/null 2>&1 || \
 		codex mcp add chrome-devtools -- npx chrome-devtools-mcp@latest
+
+codex-user-config-migrate: ## 旧Stow symlinkを内容を保持した通常ファイルへ移行
+	@set -eu; \
+	user_config="$(CODEX_USER_CONFIG)"; \
+	legacy_path='packages/codex/.codex/config.toml'; \
+	if [ ! -L "$$user_config" ]; then \
+		exit 0; \
+	fi; \
+	link_target=$$(readlink "$$user_config"); \
+	case "$$link_target" in \
+		/*) target_path="$$link_target" ;; \
+		*) target_dir=$$(cd "$$(dirname "$$user_config")/$$(dirname "$$link_target")" 2>/dev/null && pwd -P) || { \
+			printf '%s\n' "管理元を確認できない symlink を保持します: $$user_config -> $$link_target" >&2; \
+			exit 1; \
+		}; \
+		target_path="$$target_dir/$$(basename "$$link_target")" ;; \
+	esac; \
+	target_repo=$$(git -C "$$(dirname "$$target_path")" rev-parse --show-toplevel 2>/dev/null) || { \
+		printf '%s\n' "管理外の symlink を保持します: $$user_config -> $$link_target" >&2; \
+		exit 1; \
+	}; \
+	current_origin=$$(git config --get remote.origin.url); \
+	target_origin=$$(git -C "$$target_repo" config --get remote.origin.url); \
+	if [ "$$target_path" != "$$target_repo/$$legacy_path" ] || [ "$$target_origin" != "$$current_origin" ]; then \
+		printf '%s\n' "管理外の symlink を保持します: $$user_config -> $$link_target" >&2; \
+		exit 1; \
+	fi; \
+	tmp_file=$$(mktemp "$$(dirname "$$user_config")/.config.toml.migrate.XXXXXX"); \
+	if [ -f "$$user_config" ]; then \
+		cp -p "$$user_config" "$$tmp_file"; \
+	else \
+		legacy_commit=$$(git -C "$$target_repo" log -1 --format=%H --all -- "$$legacy_path"); \
+		if [ -z "$$legacy_commit" ] || ! git -C "$$target_repo" show "$$legacy_commit:$$legacy_path" >"$$tmp_file"; then \
+			printf '%s\n' "旧 user config の内容を復元できません: $$user_config" >&2; \
+			exit 1; \
+		fi; \
+	fi; \
+	mv -f "$$tmp_file" "$$user_config"; \
+	printf '%s\n' "通常ファイルへ移行しました: $$user_config"
+
+codex-system-config-dry-run: ## system configの適用内容または差分を表示
+	@set -eu; \
+	source="$(CODEX_SHARED_CONFIG)"; \
+	destination="$(CODEX_SYSTEM_CONFIG)"; \
+	if $(CODEX_CONFIG_SUDO) test -L "$$destination" && ! $(CODEX_CONFIG_SUDO) test -e "$$destination"; then \
+		printf '%s\n' "壊れた symlink のため内容を比較できません: $$destination" >&2; \
+		exit 1; \
+	fi; \
+	if $(CODEX_CONFIG_SUDO) test -e "$$destination"; then \
+		tmp_file=$$(mktemp); \
+		$(CODEX_CONFIG_SUDO) cat "$$destination" >"$$tmp_file"; \
+		if cmp -s "$$tmp_file" "$$source"; then \
+			printf '%s\n' "変更はありません: $$destination"; \
+		else \
+			printf '%s\n' "適用予定の差分: $$destination"; \
+			diff -u "$$tmp_file" "$$source" || true; \
+		fi; \
+		rm -f "$$tmp_file"; \
+	else \
+		printf '%s\n' "新規作成予定: $$destination"; \
+		sed -n '1,$$p' "$$source"; \
+	fi
+
+codex-system-config-install: codex-system-config-dry-run ## 共有Codex設定をsystem configへ導入・更新
+	@set -eu; \
+	source="$(CODEX_SHARED_CONFIG)"; \
+	destination="$(CODEX_SYSTEM_CONFIG)"; \
+	if $(CODEX_CONFIG_SUDO) test -e "$$destination"; then \
+		tmp_file=$$(mktemp); \
+		$(CODEX_CONFIG_SUDO) cat "$$destination" >"$$tmp_file"; \
+		if cmp -s "$$tmp_file" "$$source"; then \
+			rm -f "$$tmp_file"; \
+			printf '%s\n' "既に最新です: $$destination"; \
+			exit 0; \
+		fi; \
+		rm -f "$$tmp_file"; \
+		printf '既存の %s を上記内容で更新しますか? [y/N] ' "$$destination"; \
+		read -r answer; \
+		case "$$answer" in y|Y) ;; *) printf '%s\n' '更新を中止しました。'; exit 1 ;; esac; \
+	elif $(CODEX_CONFIG_SUDO) test -L "$$destination"; then \
+		printf '%s\n' "壊れた symlink は自動更新しません: $$destination" >&2; \
+		exit 1; \
+	fi; \
+	$(CODEX_CONFIG_SUDO) install -d -m 0755 "$$(dirname "$$destination")"; \
+	$(CODEX_CONFIG_SUDO) install -m 0644 "$$source" "$$destination"; \
+	printf '%s\n' "導入しました: $$destination"
+
+codex-system-config-check: ## 共有Codex設定を一時CODEX_HOMEで非破壊検証
+	@set -eu; \
+	tmp_dir=$$(mktemp -d); \
+	trap 'rm -rf "$$tmp_dir"' EXIT HUP INT TERM; \
+	cp "$(CODEX_SHARED_CONFIG)" "$$tmp_dir/config.toml"; \
+	report="$$tmp_dir/doctor.json"; \
+	CODEX_HOME="$$tmp_dir" codex doctor --json >"$$report" || true; \
+	jq -e ' \
+		.checks["config.load"].status == "ok" and \
+		(.checks["config.load"].details["feature flag overrides"] | contains("runtime_metrics=true")) and \
+		.checks["sandbox.helpers"].details["approval policy"] == "OnRequest" and \
+		.checks["sandbox.helpers"].details["filesystem sandbox"] == "unrestricted" \
+	' "$$report" >/dev/null; \
+	printf '%s\n' '共有Codex設定の読み込みと代表値を確認しました。'
+
+codex-system-config-verify: ## 導入済みsystem configの有効値をcodex doctorで検証
+	@set -eu; \
+	tmp_dir=$$(mktemp -d); \
+	trap 'rm -rf "$$tmp_dir"' EXIT HUP INT TERM; \
+	cp "$(CODEX_SHARED_CONFIG)" "$$tmp_dir/config.toml"; \
+	CODEX_HOME="$$tmp_dir" codex doctor --json >"$$tmp_dir/expected.json" || true; \
+	codex doctor --json >"$$tmp_dir/actual.json" || true; \
+	jq -e --slurpfile expected "$$tmp_dir/expected.json" ' \
+		.checks["config.load"].status == "ok" and \
+		.checks["config.load"].details.model == $$expected[0].checks["config.load"].details.model and \
+		.checks["config.load"].details["feature flag overrides"] == $$expected[0].checks["config.load"].details["feature flag overrides"] and \
+		.checks["sandbox.helpers"].details["approval policy"] == $$expected[0].checks["sandbox.helpers"].details["approval policy"] and \
+		.checks["sandbox.helpers"].details["filesystem sandbox"] == $$expected[0].checks["sandbox.helpers"].details["filesystem sandbox"] \
+	' "$$tmp_dir/actual.json" >/dev/null; \
+	printf '%s\n' '有効なCodex設定の代表値を確認しました。'
 
 claude-permissions-promote: ## WebFetch 履歴のドメインを Claude Code の許可設定へ反映
 	./scripts/promote-webfetch.sh

--- a/Makefile
+++ b/Makefile
@@ -255,31 +255,47 @@ codex-user-config-migrate: ## 旧Stow symlinkを内容を保持した通常フ�
 		printf '%s\n' "管理外の symlink を保持します: $$user_config -> $$link_target" >&2; \
 		exit 1; \
 	}; \
-	current_origin=$$(git config --get remote.origin.url); \
-	target_origin=$$(git -C "$$target_repo" config --get remote.origin.url); \
-	if [ "$$target_path" != "$$target_repo/$$legacy_path" ] || [ "$$target_origin" != "$$current_origin" ]; then \
+	current_common_dir=$$(git rev-parse --path-format=absolute --git-common-dir); \
+	target_common_dir=$$(git -C "$$target_repo" rev-parse --path-format=absolute --git-common-dir); \
+	current_origin=$$(git config --get remote.origin.url 2>/dev/null || true); \
+	target_origin=$$(git -C "$$target_repo" config --get remote.origin.url 2>/dev/null || true); \
+	normalize_origin() { printf '%s\n' "$$1" | sed -E 's#^git@github.com:#https://github.com/#; s#^ssh://git@github.com/#https://github.com/#; s#\.git$$##'; }; \
+	current_origin=$$(normalize_origin "$$current_origin"); \
+	target_origin=$$(normalize_origin "$$target_origin"); \
+	if [ "$$target_path" != "$$target_repo/$$legacy_path" ] || { \
+		[ "$$target_common_dir" != "$$current_common_dir" ] && { \
+			[ -z "$$current_origin" ] || [ "$$target_origin" != "$$current_origin" ]; \
+		}; \
+	}; then \
 		printf '%s\n' "管理外の symlink を保持します: $$user_config -> $$link_target" >&2; \
 		exit 1; \
 	fi; \
 	tmp_file=$$(mktemp "$$(dirname "$$user_config")/.config.toml.migrate.XXXXXX"); \
+	trap 'rm -f "$$tmp_file"' 0 1 2 15; \
 	if [ -f "$$user_config" ]; then \
 		cp -p "$$user_config" "$$tmp_file"; \
 	else \
-		legacy_commit=$$(git -C "$$target_repo" log -1 --format=%H --all -- "$$legacy_path"); \
+		legacy_commit=$$(for commit in $$(git -C "$$target_repo" log --format=%H --all -- "$$legacy_path"); do \
+			if git -C "$$target_repo" cat-file -e "$$commit:$$legacy_path" 2>/dev/null; then \
+				printf '%s\n' "$$commit"; \
+				break; \
+			fi; \
+		done); \
 		if [ -z "$$legacy_commit" ] || ! git -C "$$target_repo" show "$$legacy_commit:$$legacy_path" >"$$tmp_file"; then \
 			printf '%s\n' "旧 user config の内容を復元できません: $$user_config" >&2; \
 			exit 1; \
 		fi; \
 	fi; \
 	mv -f "$$tmp_file" "$$user_config"; \
+	trap - 0 1 2 15; \
 	printf '%s\n' "通常ファイルへ移行しました: $$user_config"
 
 codex-system-config-dry-run: ## system configの適用内容または差分を表示
 	@set -eu; \
 	source="$(CODEX_SHARED_CONFIG)"; \
 	destination="$(CODEX_SYSTEM_CONFIG)"; \
-	if $(CODEX_CONFIG_SUDO) test -L "$$destination" && ! $(CODEX_CONFIG_SUDO) test -e "$$destination"; then \
-		printf '%s\n' "壊れた symlink のため内容を比較できません: $$destination" >&2; \
+	if $(CODEX_CONFIG_SUDO) test -L "$$destination"; then \
+		printf '%s\n' "symlink は自動処理しません: $$destination" >&2; \
 		exit 1; \
 	fi; \
 	if $(CODEX_CONFIG_SUDO) test -e "$$destination"; then \
@@ -313,9 +329,6 @@ codex-system-config-install: codex-system-config-dry-run ## 共有Codex設定を
 		printf '既存の %s を上記内容で更新しますか? [y/N] ' "$$destination"; \
 		read -r answer; \
 		case "$$answer" in y|Y) ;; *) printf '%s\n' '更新を中止しました。'; exit 1 ;; esac; \
-	elif $(CODEX_CONFIG_SUDO) test -L "$$destination"; then \
-		printf '%s\n' "壊れた symlink は自動更新しません: $$destination" >&2; \
-		exit 1; \
 	fi; \
 	$(CODEX_CONFIG_SUDO) install -d -m 0755 "$$(dirname "$$destination")"; \
 	$(CODEX_CONFIG_SUDO) install -m 0644 "$$source" "$$destination"; \
@@ -338,11 +351,22 @@ codex-system-config-check: ## 共有Codex設定を一時CODEX_HOMEで非破壊�
 
 codex-system-config-verify: ## 導入済みsystem configの有効値をcodex doctorで検証
 	@set -eu; \
+	source="$(CODEX_SHARED_CONFIG)"; \
+	destination="$(CODEX_SYSTEM_CONFIG)"; \
+	if $(CODEX_CONFIG_SUDO) test -L "$$destination" || ! $(CODEX_CONFIG_SUDO) test -f "$$destination"; then \
+		printf '%s\n' "system config が通常ファイルとして導入されていません: $$destination" >&2; \
+		exit 1; \
+	fi; \
+	if ! $(CODEX_CONFIG_SUDO) cmp -s "$$source" "$$destination"; then \
+		printf '%s\n' "system config が共有設定の正本と一致しません: $$destination" >&2; \
+		exit 1; \
+	fi; \
 	tmp_dir=$$(mktemp -d); \
 	trap 'rm -rf "$$tmp_dir"' EXIT HUP INT TERM; \
-	cp "$(CODEX_SHARED_CONFIG)" "$$tmp_dir/config.toml"; \
-	CODEX_HOME="$$tmp_dir" codex doctor --json >"$$tmp_dir/expected.json" || true; \
-	codex doctor --json >"$$tmp_dir/actual.json" || true; \
+	mkdir "$$tmp_dir/expected-home" "$$tmp_dir/actual-home"; \
+	cp "$$source" "$$tmp_dir/expected-home/config.toml"; \
+	CODEX_HOME="$$tmp_dir/expected-home" codex doctor --json >"$$tmp_dir/expected.json" || true; \
+	CODEX_HOME="$$tmp_dir/actual-home" codex doctor --json >"$$tmp_dir/actual.json" || true; \
 	jq -e --slurpfile expected "$$tmp_dir/expected.json" ' \
 		.checks["config.load"].status == "ok" and \
 		.checks["config.load"].details.model == $$expected[0].checks["config.load"].details.model and \

--- a/README.md
+++ b/README.md
@@ -31,7 +31,38 @@ make codex-system-config-verify
 
 既存の管理外 `/etc/codex/config.toml` が異なる場合、installターゲットは差分を表示して確認を求め、同意なしには上書きしない。同じ内容が導入済みなら何も変更しない。system configのsymlinkはリンク先を意図せず読み書きしないよう、正常・リンク切れを問わず自動処理しない。`make codex-system-config-check` は実マシンのsystem/user configを変更せず、共有設定を一時的なuser layerとして読み込み、現在のsystem layerと組み合わせたときの構文と代表値を検査する。Codexにはsystem layerを無効化する診断オプションがないため、完全な単体検査ではない。
 
-旧構成からの移行では、`make stow-link` が先に `make codex-user-config-migrate` を実行する。`~/.codex/config.toml` がこのdotfilesの旧 `packages/codex/.codex/config.toml` を指すsymlinkの場合だけ、現在の内容（リンク先が削除済みならGit履歴上の最終内容）を保持した通常ファイルへ置き換える。既存の通常ファイルには触れず、管理外symlinkはエラーにして自動変更しない。移行後はuser config内の共有キーを必要に応じて削除し、project trust、hook承認、marketplace、Desktop / MCPのパスなどmachine-localな設定・状態だけを残す。
+旧構成から更新する場合は、`make stow-link` の前に一度だけ次を実行する。通常ファイルなら何も変更せず、このdotfilesの旧 `packages/codex/.codex/config.toml` を指すsymlinkだけを、内容を退避してから同じパスの通常ファイルへ置き換える。リンク先がすでに削除されていてもGit履歴から最終内容を復元する。対象外のsymlinkでは停止するため、リンク先を意図せず変更しない。
+
+```sh
+(
+  set -eu
+  user_config="$HOME/.codex/config.toml"
+  legacy_path="packages/codex/.codex/config.toml"
+
+  [ -L "$user_config" ] || exit 0
+  link_target=$(readlink "$user_config")
+  case "$link_target" in
+    *"/$legacy_path") ;;
+    *) echo "対象外のsymlinkを保持します: $user_config -> $link_target" >&2; exit 1 ;;
+  esac
+
+  tmp_file=$(mktemp "$HOME/.codex/config.toml.migrate.XXXXXX")
+  trap 'rm -f "$tmp_file"' EXIT HUP INT TERM
+  if [ -e "$user_config" ]; then
+    cp -pL "$user_config" "$tmp_file"
+  else
+    legacy_commit=$(git log --all --format=%H -- "$legacy_path" | while read -r commit; do
+      git cat-file -e "$commit:$legacy_path" 2>/dev/null && { echo "$commit"; break; }
+    done)
+    [ -n "$legacy_commit" ]
+    git show "$legacy_commit:$legacy_path" >"$tmp_file"
+  fi
+  mv "$tmp_file" "$user_config"
+  trap - EXIT HUP INT TERM
+)
+```
+
+この手順はdotfilesリポジトリのルートで実行する。完了後に `test -f "$HOME/.codex/config.toml" && test ! -L "$HOME/.codex/config.toml"` で通常ファイル化を確認してから `make stow-link` を実行する。user config内の共有キーは必要に応じて削除し、project trust、hook承認、marketplace、Desktop / MCPのパスなどmachine-localな設定・状態だけを残す。
 
 `packages/codex/.codex/` では引き続き `AGENTS.md` と `rules/default.rules` だけをStow管理する。project trust、hook状態、marketplaceキャッシュ、Codex Desktopが生成したMCP/runtimeの絶対パス、TUIのmachine-local状態は共有設定へ追加しない。
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ make codex-system-config-install
 make codex-system-config-verify
 ```
 
-既存の管理外 `/etc/codex/config.toml` が異なる場合、installターゲットは差分を表示して確認を求め、同意なしには上書きしない。同じ内容が導入済みなら何も変更しない。`make codex-system-config-check` は実マシンのsystem/user configを変更せず、一時的な `CODEX_HOME` で共有設定の構文と代表値を検査する。
+既存の管理外 `/etc/codex/config.toml` が異なる場合、installターゲットは差分を表示して確認を求め、同意なしには上書きしない。同じ内容が導入済みなら何も変更しない。system configのsymlinkはリンク先を意図せず読み書きしないよう、正常・リンク切れを問わず自動処理しない。`make codex-system-config-check` は実マシンのsystem/user configを変更せず、一時的な `CODEX_HOME` で共有設定の構文と代表値を検査する。
 
 旧構成からの移行では、`make stow-link` が先に `make codex-user-config-migrate` を実行する。`~/.codex/config.toml` がこのdotfilesの旧 `packages/codex/.codex/config.toml` を指すsymlinkの場合だけ、現在の内容（リンク先が削除済みならGit履歴上の最終内容）を保持した通常ファイルへ置き換える。既存の通常ファイルには触れず、管理外symlinkはエラーにして自動変更しない。移行後はuser config内の共有キーを必要に応じて削除し、project trust、hook承認、marketplace、Desktop / MCPのパスなどmachine-localな設定・状態だけを残す。
 

--- a/README.md
+++ b/README.md
@@ -17,6 +17,24 @@ make install
 
 MCP設定は各ツール自身の設定ファイルを更新するため、Stow管理との衝突を避けて一括セットアップから分離している。必要な場合は `make mcp-setup` を明示的に実行する。
 
+### Codex設定
+
+複数マシンで共有するCodexのデフォルト設定は [`config/codex/config.toml`](./config/codex/config.toml) を正本とし、`/etc/codex/config.toml` へ導入する。Codex自身が更新する `~/.codex/config.toml` はmachine-localな通常ファイルとしてGit / Stow管理から外す。Codexはuser configをsystem configより優先するため、user configに同じキーがある場合はmachine-localな値が有効になる。
+
+新規セットアップまたは共有設定の更新時は、先に適用内容を確認してから導入・検証する。
+
+```sh
+make codex-system-config-dry-run
+make codex-system-config-install
+make codex-system-config-verify
+```
+
+既存の管理外 `/etc/codex/config.toml` が異なる場合、installターゲットは差分を表示して確認を求め、同意なしには上書きしない。同じ内容が導入済みなら何も変更しない。`make codex-system-config-check` は実マシンのsystem/user configを変更せず、一時的な `CODEX_HOME` で共有設定の構文と代表値を検査する。
+
+旧構成からの移行では、`make stow-link` が先に `make codex-user-config-migrate` を実行する。`~/.codex/config.toml` がこのdotfilesの旧 `packages/codex/.codex/config.toml` を指すsymlinkの場合だけ、現在の内容（リンク先が削除済みならGit履歴上の最終内容）を保持した通常ファイルへ置き換える。既存の通常ファイルには触れず、管理外symlinkはエラーにして自動変更しない。移行後はuser config内の共有キーを必要に応じて削除し、project trust、hook承認、marketplace、Desktop / MCPのパスなどmachine-localな設定・状態だけを残す。
+
+`packages/codex/.codex/` では引き続き `AGENTS.md` と `rules/default.rules` だけをStow管理する。project trust、hook状態、marketplaceキャッシュ、Codex Desktopが生成したMCP/runtimeの絶対パス、TUIのmachine-local状態は共有設定へ追加しない。
+
 ### Agent skill
 
 `make skills-install` は管理対象のagent skillを単一の正本として `~/.agents/skills/<name>` にインストールする。Codexはこの共通ディレクトリから直接読み込み、Claude Codeは `~/.claude/skills/<name>` から正本へのsymlinkを介して同じskillを利用する。これにより、両方のskill selectorに同名skillが重複して表示されない。
@@ -25,22 +43,26 @@ MCP設定は各ツール自身の設定ファイルを更新するため、Stow�
 
 ## 主要コマンド
 
-| Command               | 用途                                              |
-| --------------------- | ------------------------------------------------- |
-| `make help`           | 利用可能なタスク一覧を表示                        |
-| `make install`        | dotfiles環境を一括セットアップ                    |
-| `make update`         | 管理対象のパッケージと外部リソースを一括更新      |
-| `make doctor`         | dotfilesの設定状態を読み取り専用で検査            |
-| `make brew-install`   | `Brewfile` のパッケージをインストール             |
-| `make brew-update`    | Homebrewと `Brewfile` のパッケージを更新          |
-| `make brewfile-dump`  | 現在のHomebrew状態を `Brewfile` に書き出し        |
-| `make brew-prune`     | `Brewfile` にないHomebrewパッケージを確認後に削除 |
-| `make stow-link`      | `packages/` 配下を `$HOME` にシンボリックリンク化 |
-| `make stow-unlink`    | Stow管理のシンボリックリンクを削除                |
-| `make mise-install`   | mise管理の開発CLIとTerraformをインストール        |
-| `make skills-install` | 管理対象のagent skillをインストール               |
-| `make skills-update`  | インストール済みのagent skillを更新               |
-| `make mcp-setup`      | Claude CodeとCodexのMCPサーバーを設定             |
+| Command                            | 用途                                              |
+| ---------------------------------- | ------------------------------------------------- |
+| `make help`                        | 利用可能なタスク一覧を表示                        |
+| `make install`                     | dotfiles環境を一括セットアップ                    |
+| `make update`                      | 管理対象のパッケージと外部リソースを一括更新      |
+| `make doctor`                      | dotfilesの設定状態を読み取り専用で検査            |
+| `make brew-install`                | `Brewfile` のパッケージをインストール             |
+| `make brew-update`                 | Homebrewと `Brewfile` のパッケージを更新          |
+| `make brewfile-dump`               | 現在のHomebrew状態を `Brewfile` に書き出し        |
+| `make brew-prune`                  | `Brewfile` にないHomebrewパッケージを確認後に削除 |
+| `make stow-link`                   | `packages/` 配下を `$HOME` にシンボリックリンク化 |
+| `make stow-unlink`                 | Stow管理のシンボリックリンクを削除                |
+| `make mise-install`                | mise管理の開発CLIとTerraformをインストール        |
+| `make skills-install`              | 管理対象のagent skillをインストール               |
+| `make skills-update`               | インストール済みのagent skillを更新               |
+| `make codex-system-config-dry-run` | Codex system configの適用内容・差分を表示         |
+| `make codex-system-config-install` | Codexの共有設定を `/etc/codex/config.toml` へ導入 |
+| `make codex-system-config-check`   | Codex共有設定を一時ディレクトリで非破壊検証       |
+| `make codex-system-config-verify`  | 導入後のCodex設定の代表値を診断                   |
+| `make mcp-setup`                   | Claude CodeとCodexのMCPサーバーを設定             |
 
 ## 詳細
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ make codex-system-config-install
 make codex-system-config-verify
 ```
 
-既存の管理外 `/etc/codex/config.toml` が異なる場合、installターゲットは差分を表示して確認を求め、同意なしには上書きしない。同じ内容が導入済みなら何も変更しない。system configのsymlinkはリンク先を意図せず読み書きしないよう、正常・リンク切れを問わず自動処理しない。`make codex-system-config-check` は実マシンのsystem/user configを変更せず、一時的な `CODEX_HOME` で共有設定の構文と代表値を検査する。
+既存の管理外 `/etc/codex/config.toml` が異なる場合、installターゲットは差分を表示して確認を求め、同意なしには上書きしない。同じ内容が導入済みなら何も変更しない。system configのsymlinkはリンク先を意図せず読み書きしないよう、正常・リンク切れを問わず自動処理しない。`make codex-system-config-check` は実マシンのsystem/user configを変更せず、共有設定を一時的なuser layerとして読み込み、現在のsystem layerと組み合わせたときの構文と代表値を検査する。Codexにはsystem layerを無効化する診断オプションがないため、完全な単体検査ではない。
 
 旧構成からの移行では、`make stow-link` が先に `make codex-user-config-migrate` を実行する。`~/.codex/config.toml` がこのdotfilesの旧 `packages/codex/.codex/config.toml` を指すsymlinkの場合だけ、現在の内容（リンク先が削除済みならGit履歴上の最終内容）を保持した通常ファイルへ置き換える。既存の通常ファイルには触れず、管理外symlinkはエラーにして自動変更しない。移行後はuser config内の共有キーを必要に応じて削除し、project trust、hook承認、marketplace、Desktop / MCPのパスなどmachine-localな設定・状態だけを残す。
 

--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ MCP設定は各ツール自身の設定ファイルを更新するため、Stow�
 
 複数マシンで共有するCodexのデフォルト設定は [`config/codex/config.toml`](./config/codex/config.toml) を正本とし、`/etc/codex/config.toml` へ導入する。Codex自身が更新する `~/.codex/config.toml` はmachine-localな通常ファイルとしてGit / Stow管理から外す。Codexはuser configをsystem configより優先するため、user configに同じキーがある場合はmachine-localな値が有効になる。
 
+共有設定の `sandbox_mode = "danger-full-access"` は、個人専用macOSでの利用を前提とする既存値である。共有端末へ導入する場合は、この値を `workspace-write` へ変更する。
+
 新規セットアップまたは共有設定の更新時は、先に適用内容を確認してから導入・検証する。
 
 ```sh
@@ -31,38 +33,26 @@ make codex-system-config-verify
 
 既存の管理外 `/etc/codex/config.toml` が異なる場合、installターゲットは差分を表示して確認を求め、同意なしには上書きしない。同じ内容が導入済みなら何も変更しない。system configのsymlinkはリンク先を意図せず読み書きしないよう、正常・リンク切れを問わず自動処理しない。`make codex-system-config-check` は実マシンのsystem/user configを変更せず、共有設定を一時的なuser layerとして読み込み、現在のsystem layerと組み合わせたときの構文と代表値を検査する。Codexにはsystem layerを無効化する診断オプションがないため、完全な単体検査ではない。
 
-旧構成から更新する場合は、`make stow-link` の前に一度だけ次を実行する。通常ファイルなら何も変更せず、このdotfilesの旧 `packages/codex/.codex/config.toml` を指すsymlinkだけを、内容を退避してから同じパスの通常ファイルへ置き換える。リンク先がすでに削除されていてもGit履歴から最終内容を復元する。対象外のsymlinkでは停止するため、リンク先を意図せず変更しない。
+旧構成から更新する場合、`~/.codex/config.toml` が通常ファイルなら移行は不要である。symlinkの場合は `make stow-link` の前に `readlink` の出力を確認し、このdotfilesの `packages/codex/.codex/config.toml` を指していることを人が確認してから、一度だけ内容を保持した通常ファイルへ置き換える。
 
 ```sh
-(
-  set -eu
-  user_config="$HOME/.codex/config.toml"
-  legacy_path="packages/codex/.codex/config.toml"
-
-  [ -L "$user_config" ] || exit 0
-  link_target=$(readlink "$user_config")
-  case "$link_target" in
-    *"/$legacy_path") ;;
-    *) echo "対象外のsymlinkを保持します: $user_config -> $link_target" >&2; exit 1 ;;
-  esac
-
-  tmp_file=$(mktemp "$HOME/.codex/config.toml.migrate.XXXXXX")
-  trap 'rm -f "$tmp_file"' EXIT HUP INT TERM
-  if [ -e "$user_config" ]; then
-    cp -pL "$user_config" "$tmp_file"
-  else
-    legacy_commit=$(git log --all --format=%H -- "$legacy_path" | while read -r commit; do
-      git cat-file -e "$commit:$legacy_path" 2>/dev/null && { echo "$commit"; break; }
-    done)
-    [ -n "$legacy_commit" ]
-    git show "$legacy_commit:$legacy_path" >"$tmp_file"
-  fi
-  mv "$tmp_file" "$user_config"
-  trap - EXIT HUP INT TERM
-)
+readlink "$HOME/.codex/config.toml"
+tmp_file=$(mktemp "$HOME/.codex/config.toml.migrate.XXXXXX")
+cp -pL "$HOME/.codex/config.toml" "$tmp_file"
+mv "$tmp_file" "$HOME/.codex/config.toml"
+test -f "$HOME/.codex/config.toml" && test ! -L "$HOME/.codex/config.toml"
 ```
 
-この手順はdotfilesリポジトリのルートで実行する。完了後に `test -f "$HOME/.codex/config.toml" && test ! -L "$HOME/.codex/config.toml"` で通常ファイル化を確認してから `make stow-link` を実行する。user config内の共有キーは必要に応じて削除し、project trust、hook承認、marketplace、Desktop / MCPのパスなどmachine-localな設定・状態だけを残す。
+symlinkがすでにリンク切れの場合は、dotfilesリポジトリのルートで `git log --all -- packages/codex/.codex/config.toml` を確認し、削除前のcommitから一時ファイルへ復元して置き換える。
+
+```sh
+tmp_file=$(mktemp "$HOME/.codex/config.toml.migrate.XXXXXX")
+git show <削除前のcommit>:packages/codex/.codex/config.toml >"$tmp_file"
+mv "$tmp_file" "$HOME/.codex/config.toml"
+test -f "$HOME/.codex/config.toml" && test ! -L "$HOME/.codex/config.toml"
+```
+
+通常ファイル化を確認してから `make stow-link` を実行する。user config内の共有キーは必要に応じて削除し、project trust、hook承認、marketplace、Desktop / MCPのパスなどmachine-localな設定・状態だけを残す。
 
 `packages/codex/.codex/` では引き続き `AGENTS.md` と `rules/default.rules` だけをStow管理する。project trust、hook状態、marketplaceキャッシュ、Codex Desktopが生成したMCP/runtimeの絶対パス、TUIのmachine-local状態は共有設定へ追加しない。
 

--- a/config/codex/config.toml
+++ b/config/codex/config.toml
@@ -22,9 +22,3 @@ status_line = [
   "weekly-limit",
 ]
 status_line_use_colors = true
-
-[tui.model_availability_nux]
-"gpt-5.5" = 4
-
-[projects."/Users/hirokisakabe/work/dotfiles"]
-trust_level = "trusted"


### PR DESCRIPTION
close #345

## 目的

Codex の共有可能なグローバル設定を `/etc/codex/config.toml` 用の正本へ分離し、Codex が更新する `~/.codex/config.toml` を machine-local な通常ファイルとして Git / Stow 管理から外します。

## 変更内容

- `packages/codex/.codex/config.toml` を Stow 対象外の `config/codex/config.toml` へ移動
- project trust と TUI の machine-local 状態を共有正本から除外
- 旧 Stow symlink を内容保持した通常ファイルへ安全に移行するターゲットを追加
- system config の差分表示、確認付き導入、隔離診断、導入後検証ターゲットを追加
- 新規セットアップ、既存環境からの移行、設定の優先順位と更新手順を README / AGENTS.md に記載
- `packages/codex/.codex/AGENTS.md` と `rules/default.rules` の Stow 管理は維持

## 影響パス

- `Makefile`
- `README.md`
- `AGENTS.md`
- `config/codex/config.toml`
- `packages/codex/.codex/config.toml`（Stow 対象から削除）

## 検証

- `make help`
- `make codex-system-config-check`
- `npx prettier@3 --check .`
- 一時 HOME で `stow --simulate --verbose --no-folding --dir=packages --target="$tmp_home" codex`
- 一時パスで system config の新規導入・冪等更新・既存ファイル上書き拒否・symlink拒否を確認
- 一時パスで通常 user config の内容保持、旧 dangling symlink の Git 履歴からの復元、管理外 symlink の保持を確認
- `codex doctor --json` の `config.load` 成功を確認
- acceptance-check: ✓ 13 / ✗ 0 / ? 0
- cross-review: critical 0（warning / info は追加 commit で対応済み）

実マシンの `/etc/codex/config.toml` と `~/.codex/config.toml` は検証中に変更していません。
