### PR TITLE
chore: remove Obsidian from Brewfile

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -64,7 +64,6 @@ cask "libreoffice"
 cask "inkscape"
 cask "logi-options+"
 cask "deepl"
-cask "obsidian"
 
 # --- Fonts ---
 cask "font-hackgen-nerd"


### PR DESCRIPTION
## 概要

使用しなくなったObsidianをHomebrew Bundleの管理対象から削除します。

## 変更箇所

- `Brewfile`: `cask "obsidian"` を削除

## 検証

- `brew bundle list --file=Brewfile`
- Obsidianがbundle一覧に含まれないことを確認
- `git diff --check`
- `npx prettier@3 --check .`
