### PR TITLE
docs: Codex設定の詳細をREADMEから分離する

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,11 +19,7 @@ MCP設定は各ツール自身の設定ファイルを更新するため、Stow�
 
 ### Codex設定
 
-複数マシンで共有するCodexのデフォルト設定は [`config/codex/config.toml`](./config/codex/config.toml) を正本とし、`/etc/codex/config.toml` へ導入する。Codex自身が更新する `~/.codex/config.toml` はmachine-localな通常ファイルとしてGit / Stow管理から外す。Codexはuser configをsystem configより優先するため、user configに同じキーがある場合はmachine-localな値が有効になる。
-
-共有設定の `sandbox_mode = "danger-full-access"` は、個人専用macOSでの利用を前提とする既存値である。共有端末へ導入する場合は、この値を `workspace-write` へ変更する。
-
-新規セットアップまたは共有設定の更新時は、先に適用内容を確認してから導入・検証する。
+複数マシンで共有するCodex設定は [`config/codex/config.toml`](./config/codex/config.toml) を正本とし、`/etc/codex/config.toml` へ導入する。新規セットアップまたは共有設定の更新時は、適用内容を確認してから導入・検証する。
 
 ```sh
 make codex-system-config-dry-run
@@ -31,30 +27,7 @@ make codex-system-config-install
 make codex-system-config-verify
 ```
 
-既存の管理外 `/etc/codex/config.toml` が異なる場合、installターゲットは差分を表示して確認を求め、同意なしには上書きしない。同じ内容が導入済みなら何も変更しない。system configのsymlinkはリンク先を意図せず読み書きしないよう、正常・リンク切れを問わず自動処理しない。`make codex-system-config-check` は実マシンのsystem/user configを変更せず、共有設定を一時的なuser layerとして読み込み、現在のsystem layerと組み合わせたときの構文と代表値を検査する。Codexにはsystem layerを無効化する診断オプションがないため、完全な単体検査ではない。
-
-旧構成から更新する場合、`~/.codex/config.toml` が通常ファイルなら移行は不要である。symlinkの場合は `make stow-link` の前に `readlink` の出力を確認し、このdotfilesの `packages/codex/.codex/config.toml` を指していることを人が確認してから、一度だけ内容を保持した通常ファイルへ置き換える。
-
-```sh
-readlink "$HOME/.codex/config.toml"
-tmp_file=$(mktemp "$HOME/.codex/config.toml.migrate.XXXXXX")
-cp -pL "$HOME/.codex/config.toml" "$tmp_file"
-mv "$tmp_file" "$HOME/.codex/config.toml"
-test -f "$HOME/.codex/config.toml" && test ! -L "$HOME/.codex/config.toml"
-```
-
-symlinkがすでにリンク切れの場合は、dotfilesリポジトリのルートで `git log --all -- packages/codex/.codex/config.toml` を確認し、削除前のcommitから一時ファイルへ復元して置き換える。
-
-```sh
-tmp_file=$(mktemp "$HOME/.codex/config.toml.migrate.XXXXXX")
-git show <削除前のcommit>:packages/codex/.codex/config.toml >"$tmp_file"
-mv "$tmp_file" "$HOME/.codex/config.toml"
-test -f "$HOME/.codex/config.toml" && test ! -L "$HOME/.codex/config.toml"
-```
-
-通常ファイル化を確認してから `make stow-link` を実行する。user config内の共有キーは必要に応じて削除し、project trust、hook承認、marketplace、Desktop / MCPのパスなどmachine-localな設定・状態だけを残す。
-
-`packages/codex/.codex/` では引き続き `AGENTS.md` と `rules/default.rules` だけをStow管理する。project trust、hook状態、marketplaceキャッシュ、Codex Desktopが生成したMCP/runtimeの絶対パス、TUIのmachine-local状態は共有設定へ追加しない。
+設定レイヤーの役割、安全設計、検証上の制約、Stow管理との境界は [`docs/codex.md`](./docs/codex.md) を参照。
 
 ### Agent skill
 

--- a/docs/codex.md
+++ b/docs/codex.md
@@ -1,0 +1,52 @@
+# Codex設定
+
+## 設定レイヤー
+
+複数マシンで共有するデフォルト設定は [`../config/codex/config.toml`](../config/codex/config.toml) を正本とし、system configの `/etc/codex/config.toml` へ導入する。
+
+Codex自身が更新するuser configの `~/.codex/config.toml` は、machine-localな通常ファイルとしてGit / Stow管理から外す。Codexはuser configをsystem configより優先するため、両方に同じキーがある場合はmachine-localな値が有効になる。
+
+## 導入と検証
+
+新規セットアップまたは共有設定の更新時は、dry-runで適用内容を確認してから導入・検証する。
+
+```sh
+make codex-system-config-dry-run
+make codex-system-config-install
+make codex-system-config-verify
+```
+
+共有設定自体の構文と代表値は、実マシンのsystem/user configを変更せずに検査できる。
+
+```sh
+make codex-system-config-check
+```
+
+## system config導入時の安全設計
+
+- dry-runは、導入先が未作成なら新規作成する内容を、既存ファイルなら正本との差分を表示する。
+- installはdry-runを先に実行する。既存の管理外ファイルと正本が異なる場合は確認を求め、同意なしには上書きしない。
+- 正本と同じ内容が導入済みなら、installはファイルを変更しない。
+- system configがsymlinkの場合は、正常・リンク切れを問わずdry-runとinstallを停止する。リンク先を意図せず読み書きしないため、symlinkは自動処理しない。
+- installは一時ファイルを通常ファイルとして作成してから導入先へ移動し、不完全な内容が残ることを避ける。
+- verifyは導入先が通常ファイルであり、正本と一致することを確認してから有効な代表値を検査する。
+
+## `danger-full-access` の注意
+
+共有設定の `sandbox_mode = "danger-full-access"` は、個人専用macOSでの利用を前提とする。この設定ではCodexのfilesystem sandboxによる制限がないため、共有端末へそのまま導入しない。共有端末で利用する場合は、正本の値を `workspace-write` など用途に合う制限付きモードへ変更してから導入する。
+
+## `codex-system-config-check` の制約
+
+`make codex-system-config-check` は共有設定を一時的なuser layerとして読み込み、現在のsystem layerと組み合わせた状態で構文と代表値を検査する。実マシンの設定ファイルは変更しない。
+
+Codexにはsystem layerを無効化する診断オプションがないため、この検査は共有設定だけの完全な単体検査ではない。実際に導入したsystem configの確認には `make codex-system-config-verify` を使用する。
+
+## Stow管理との境界
+
+`packages/codex/.codex/` では `AGENTS.md` と `rules/default.rules` だけをStow管理する。`~/.codex/config.toml` と、次のようなmachine-localな設定・状態は共有設定へ追加しない。
+
+- project trust
+- hook承認とhook状態
+- marketplaceキャッシュ
+- Codex Desktopが生成したMCP/runtimeの絶対パス
+- TUIのmachine-local状態


### PR DESCRIPTION
close #385

## 目的

トップ README の Codex 設定セクションを通常利用に必要な情報へ絞り、継続参照する設定レイヤー、安全設計、運用上の注意を専用文書へ分離します。

## 変更内容

- `README.md` の Codex 設定セクションを、共有設定の正本・導入先・通常の導入／検証コマンド・詳細文書へのリンクを中心に簡潔化
- `docs/codex.md` を追加し、設定レイヤーの役割、system config 導入時の安全設計、`danger-full-access` の注意、診断上の制約、Stow 管理との境界を整理
- 完了済みの旧構成 migration 手順は README および新文書に残さず削除
- README の主要コマンド一覧と既存 Make ターゲット名は維持

## 影響範囲

- `README.md`
- `docs/codex.md`

設定値、設定ファイル配置、Makefile、shell script の動作には変更ありません。

## 検証

- `npx prettier@3 --check .`
- `git diff --check origin/main...HEAD`
- 文書内の相対リンクと既存 Make ターゲット名を確認
