### PR TITLE
refactor: Makefile の複雑な処理を Shell Script へ分離する

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,15 @@
+name: Test
+
+on:
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v6
+      - run: make test

--- a/Makefile
+++ b/Makefile
@@ -110,88 +110,10 @@ mise-install: ## mise 管理の開発ツールをインストール
 	mise install
 
 skills-install: ## 管理対象の agent skill をインストール
-	@mkdir -p "$(AGENT_SKILLS_DIR)" "$(CLAUDE_SKILLS_DIR)"
-	@set -e; \
-	is_managed_skill() { \
-		skill_file_path="$$1/SKILL.md"; \
-		expected_repository="https://github.com/$$2"; \
-		expected_skill_path="skills/$$3"; \
-		[ -f "$$skill_file_path" ] || return 1; \
-		awk -v expected_repository="$$expected_repository" -v expected_skill_path="$$expected_skill_path" ' \
-			NR == 1 { if ($$0 != "---") exit 1; frontmatter = 1; next } \
-			frontmatter && $$0 == "---" { \
-				closed = 1; \
-				valid_sha = length(tree_sha) == 40 && tree_sha !~ /[^0-9a-f]/; \
-				exit !(metadata_count == 1 && !invalid_metadata && repo_count == 1 && path_count == 1 && sha_count == 1 && repository == expected_repository && skill_path == expected_skill_path && valid_sha); \
-			} \
-			frontmatter && $$0 == "metadata:" { metadata = 1; metadata_count++; next } \
-			metadata && /^[^[:space:]]/ { metadata = 0 } \
-			metadata && /^  [^ ]/ { invalid_metadata = 1; metadata = 0 } \
-			metadata && /^    github-repo:[[:space:]]*/ { repo_count++; repository = $$0; sub(/^    github-repo:[[:space:]]*/, "", repository); next } \
-			metadata && /^    github-path:[[:space:]]*/ { path_count++; skill_path = $$0; sub(/^    github-path:[[:space:]]*/, "", skill_path); next } \
-			metadata && /^    github-tree-sha:[[:space:]]*/ { sha_count++; tree_sha = $$0; sub(/^    github-tree-sha:[[:space:]]*/, "", tree_sha); next } \
-			END { if (!closed) exit 1 } \
-		' "$$skill_file_path" >/dev/null; \
-	}; \
-	for skill_spec in $(AGENT_SKILLS); do \
-		repository=$${skill_spec%:*}; \
-		skill=$${skill_spec#*:}; \
-		canonical_path="$(AGENT_SKILLS_DIR)/$$skill"; \
-		claude_path="$(CLAUDE_SKILLS_DIR)/$$skill"; \
-		codex_path="$(CODEX_SKILLS_DIR)/$$skill"; \
-		if [ -L "$$canonical_path" ]; then \
-			if is_managed_skill "$$canonical_path" "$$repository" "$$skill"; then \
-				rm -f "$$canonical_path"; \
-			else \
-				printf '%s\n' "管理外の symlink と競合しています: $$canonical_path" >&2; \
-				exit 1; \
-			fi; \
-		elif [ -e "$$canonical_path" ] && ! is_managed_skill "$$canonical_path" "$$repository" "$$skill"; then \
-			printf '%s\n' "管理外の既存 skill と競合しています: $$canonical_path" >&2; \
-			exit 1; \
-		fi; \
-		gh skill install "$$repository" "$$skill" --dir "$(AGENT_SKILLS_DIR)" -f; \
-		if [ -L "$$claude_path" ]; then \
-			target=$$(readlink "$$claude_path"); \
-			if [ "$$claude_path" -ef "$$canonical_path" ]; then \
-				:; \
-			elif [ ! -e "$$claude_path" ]; then \
-				printf '%s\n' "既存の壊れた外部 symlink を保持します: $$claude_path -> $$target"; \
-			elif is_managed_skill "$$claude_path" "$$repository" "$$skill"; then \
-				rm -f "$$claude_path"; \
-			else \
-				printf '%s\n' "既存の外部 symlink を保持します: $$claude_path -> $$target"; \
-			fi; \
-		elif [ -e "$$claude_path" ]; then \
-			if is_managed_skill "$$claude_path" "$$repository" "$$skill"; then \
-				rm -rf "$$claude_path"; \
-			else \
-				printf '%s\n' "管理外の既存 skill を保持します: $$claude_path"; \
-			fi; \
-		fi; \
-		if [ ! -e "$$claude_path" ] && [ ! -L "$$claude_path" ]; then \
-			if [ "$(AGENT_SKILLS_DIR)" = "$(HOME)/.agents/skills" ] && [ "$(CLAUDE_SKILLS_DIR)" = "$(HOME)/.claude/skills" ]; then \
-				link_target="../../.agents/skills/$$skill"; \
-			else \
-				link_target="$$canonical_path"; \
-			fi; \
-			ln -s "$$link_target" "$$claude_path"; \
-		fi; \
-		if [ -L "$$codex_path" ]; then \
-			target=$$(readlink "$$codex_path"); \
-			if [ -e "$$codex_path" ] && { [ "$$codex_path" -ef "$$canonical_path" ] || is_managed_skill "$$codex_path" "$$repository" "$$skill"; }; then \
-				rm -f "$$codex_path"; \
-			else \
-				printf '%s\n' "既存の外部 symlink を保持します: $$codex_path -> $$target"; \
-			fi; \
-		elif [ -e "$$codex_path" ]; then \
-			if is_managed_skill "$$codex_path" "$$repository" "$$skill"; then \
-				rm -rf "$$codex_path"; \
-			else \
-				printf '%s\n' "管理外の既存 skill を保持します: $$codex_path"; \
-			fi; \
-		fi; \
-	done
+	@AGENT_SKILLS_DIR="$(AGENT_SKILLS_DIR)" \
+	CLAUDE_SKILLS_DIR="$(CLAUDE_SKILLS_DIR)" \
+	CODEX_SKILLS_DIR="$(CODEX_SKILLS_DIR)" \
+		./scripts/skills-install.sh $(AGENT_SKILLS)
 
 skills-update: ## インストール済みの agent skill を更新
 	gh skill update --all --dir "$(AGENT_SKILLS_DIR)"
@@ -235,169 +157,23 @@ codex-mcp-setup: ## Codex の MCP サーバーを設定
 		codex mcp add chrome-devtools -- npx chrome-devtools-mcp@latest
 
 codex-system-config-dry-run: ## system configの適用内容または差分を表示
-	@set -eu; \
-	umask 077; \
-	source="$(CODEX_SHARED_CONFIG)"; \
-	destination="$(CODEX_SYSTEM_CONFIG)"; \
-	if $(CODEX_CONFIG_SUDO) test -L "$$destination"; then \
-		printf '%s\n' "symlink は自動処理しません: $$destination" >&2; \
-		exit 1; \
-	fi; \
-	if $(CODEX_CONFIG_SUDO) test -e "$$destination"; then \
-		tmp_file=$$(mktemp); \
-		trap 'rm -f "$$tmp_file"' 0 1 2 15; \
-		$(CODEX_CONFIG_SUDO) cat "$$destination" >"$$tmp_file"; \
-		if cmp -s "$$tmp_file" "$$source"; then \
-			printf '%s\n' "変更はありません: $$destination"; \
-		else \
-			printf '%s\n' "適用予定の差分: $$destination"; \
-			diff -u "$$tmp_file" "$$source" || true; \
-		fi; \
-		rm -f "$$tmp_file"; \
-		trap - 0 1 2 15; \
-	else \
-		printf '%s\n' "新規作成予定: $$destination"; \
-		sed -n '1,$$p' "$$source"; \
-	fi
+	@CODEX_SHARED_CONFIG="$(CODEX_SHARED_CONFIG)" CODEX_SYSTEM_CONFIG="$(CODEX_SYSTEM_CONFIG)" \
+		CODEX_CONFIG_SUDO="$(CODEX_CONFIG_SUDO)" ./scripts/codex-system-config.sh dry-run
 
 codex-system-config-install: codex-system-config-dry-run ## 共有Codex設定をsystem configへ導入・更新
-	@set -eu; \
-	umask 077; \
-	source="$(CODEX_SHARED_CONFIG)"; \
-	destination="$(CODEX_SYSTEM_CONFIG)"; \
-	destination_dir=$$(dirname "$$destination"); \
-	tmp_file=''; \
-	cleanup() { \
-		if [ -n "$$tmp_file" ]; then \
-			$(CODEX_CONFIG_SUDO) rm -f "$$tmp_file"; \
-		fi; \
-	}; \
-	trap cleanup 0 1 2 15; \
-	if $(CODEX_CONFIG_SUDO) test -L "$$destination"; then \
-		printf '%s\n' "symlink は自動処理しません: $$destination" >&2; \
-		exit 1; \
-	fi; \
-	if $(CODEX_CONFIG_SUDO) test -e "$$destination"; then \
-		current_file=$$(mktemp); \
-		trap 'rm -f "$$current_file"; cleanup' 0 1 2 15; \
-		$(CODEX_CONFIG_SUDO) cat "$$destination" >"$$current_file"; \
-		if cmp -s "$$current_file" "$$source"; then \
-			rm -f "$$current_file"; \
-			trap cleanup 0 1 2 15; \
-			printf '%s\n' "既に最新です: $$destination"; \
-			exit 0; \
-		fi; \
-		rm -f "$$current_file"; \
-		trap cleanup 0 1 2 15; \
-		printf '既存の %s を上記内容で更新しますか? [y/N] ' "$$destination"; \
-		read -r answer; \
-		case "$$answer" in y|Y) ;; *) printf '%s\n' '更新を中止しました。'; exit 1 ;; esac; \
-	fi; \
-	$(CODEX_CONFIG_SUDO) install -d -m 0755 "$$destination_dir"; \
-	if $(CODEX_CONFIG_SUDO) test -L "$$destination"; then \
-		printf '%s\n' "symlink は自動処理しません: $$destination" >&2; \
-		exit 1; \
-	fi; \
-	tmp_file=$$($(CODEX_CONFIG_SUDO) mktemp "$$destination_dir/.config.toml.install.XXXXXX"); \
-	$(CODEX_CONFIG_SUDO) install -m 0644 "$$source" "$$tmp_file"; \
-	if $(CODEX_CONFIG_SUDO) test -L "$$tmp_file" || ! $(CODEX_CONFIG_SUDO) test -f "$$tmp_file"; then \
-		printf '%s\n' "一時ファイルが通常ファイルではありません: $$tmp_file" >&2; \
-		exit 1; \
-	fi; \
-	if $(CODEX_CONFIG_SUDO) test -L "$$destination"; then \
-		printf '%s\n' "symlink は自動処理しません: $$destination" >&2; \
-		exit 1; \
-	fi; \
-	$(CODEX_CONFIG_SUDO) mv -fh "$$tmp_file" "$$destination"; \
-	tmp_file=''; \
-	trap - 0 1 2 15; \
-	printf '%s\n' "導入しました: $$destination"
+	@CODEX_SHARED_CONFIG="$(CODEX_SHARED_CONFIG)" CODEX_SYSTEM_CONFIG="$(CODEX_SYSTEM_CONFIG)" \
+		CODEX_CONFIG_SUDO="$(CODEX_CONFIG_SUDO)" ./scripts/codex-system-config.sh install
 
 codex-system-config-check: ## 共有Codex設定を一時CODEX_HOMEで非破壊検証
-	@set -eu; \
-	tmp_dir=$$(mktemp -d); \
-	trap 'rm -rf "$$tmp_dir"' EXIT HUP INT TERM; \
-	cp "$(CODEX_SHARED_CONFIG)" "$$tmp_dir/config.toml"; \
-	report="$$tmp_dir/doctor.json"; \
-	CODEX_HOME="$$tmp_dir" codex doctor --json >"$$report" || true; \
-	jq -e ' \
-		.checks["config.load"].status == "ok" and \
-		(.checks["config.load"].details["feature flag overrides"] | contains("runtime_metrics=true")) and \
-		.checks["sandbox.helpers"].details["approval policy"] == "OnRequest" and \
-		.checks["sandbox.helpers"].details["filesystem sandbox"] == "unrestricted" \
-	' "$$report" >/dev/null; \
-	printf '%s\n' '共有Codex設定の読み込みと代表値を確認しました。'
+	@CODEX_SHARED_CONFIG="$(CODEX_SHARED_CONFIG)" CODEX_SYSTEM_CONFIG="$(CODEX_SYSTEM_CONFIG)" \
+		CODEX_CONFIG_SUDO="$(CODEX_CONFIG_SUDO)" ./scripts/codex-system-config.sh check
 
 codex-system-config-verify: ## 導入済みsystem configの有効値をcodex doctorで検証
-	@set -eu; \
-	source="$(CODEX_SHARED_CONFIG)"; \
-	destination="$(CODEX_SYSTEM_CONFIG)"; \
-	if $(CODEX_CONFIG_SUDO) test -L "$$destination" || ! $(CODEX_CONFIG_SUDO) test -f "$$destination"; then \
-		printf '%s\n' "system config が通常ファイルとして導入されていません: $$destination" >&2; \
-		exit 1; \
-	fi; \
-	if ! $(CODEX_CONFIG_SUDO) cmp -s "$$source" "$$destination"; then \
-		printf '%s\n' "system config が共有設定の正本と一致しません: $$destination" >&2; \
-		exit 1; \
-	fi; \
-	tmp_dir=$$(mktemp -d); \
-	trap 'rm -rf "$$tmp_dir"' EXIT HUP INT TERM; \
-	mkdir "$$tmp_dir/expected-home" "$$tmp_dir/actual-home"; \
-	cp "$$source" "$$tmp_dir/expected-home/config.toml"; \
-	CODEX_HOME="$$tmp_dir/expected-home" codex doctor --json >"$$tmp_dir/expected.json" || true; \
-	CODEX_HOME="$$tmp_dir/actual-home" codex doctor --json >"$$tmp_dir/actual.json" || true; \
-	jq -e --slurpfile expected "$$tmp_dir/expected.json" ' \
-		.checks["config.load"].status == "ok" and \
-		.checks["config.load"].details.model == $$expected[0].checks["config.load"].details.model and \
-		.checks["config.load"].details["feature flag overrides"] == $$expected[0].checks["config.load"].details["feature flag overrides"] and \
-		.checks["sandbox.helpers"].details["approval policy"] == $$expected[0].checks["sandbox.helpers"].details["approval policy"] and \
-		.checks["sandbox.helpers"].details["filesystem sandbox"] == $$expected[0].checks["sandbox.helpers"].details["filesystem sandbox"] \
-	' "$$tmp_dir/actual.json" >/dev/null; \
-	printf '%s\n' '有効なCodex設定の代表値を確認しました。'
+	@CODEX_SHARED_CONFIG="$(CODEX_SHARED_CONFIG)" CODEX_SYSTEM_CONFIG="$(CODEX_SYSTEM_CONFIG)" \
+		CODEX_CONFIG_SUDO="$(CODEX_CONFIG_SUDO)" ./scripts/codex-system-config.sh verify
 
 claude-permissions-promote: ## WebFetch 履歴のドメインを Claude Code の許可設定へ反映
 	./scripts/promote-webfetch.sh
 
 doctor: ## dotfiles のセットアップ状態を読み取り専用で検査
-	@status=0; \
-	run_check() { \
-		name="$$1"; \
-		shift; \
-		printf '\n==> %s\n' "$$name"; \
-		if "$$@"; then \
-			printf '[PASS] %s\n' "$$name"; \
-		else \
-			printf '[FAIL] %s\n' "$$name" >&2; \
-			status=1; \
-		fi; \
-	}; \
-	check_stow() { \
-		output=$$(stow --simulate --verbose --no-folding --dir=packages --target="$$HOME" $(PACKAGES) 2>&1); \
-		stow_status=$$?; \
-		[ -z "$$output" ] || printf '%s\n' "$$output"; \
-		[ "$$stow_status" -eq 0 ] || return "$$stow_status"; \
-		if printf '%s\n' "$$output" | grep -Eq '^(LINK|MKDIR):'; then \
-			printf 'Stow would create links or directories.\n' >&2; \
-			return 1; \
-		fi; \
-	}; \
-	check_gh_extensions() { \
-		output=$$(gh extension list); \
-		printf '%s\n' "$$output" | grep -Fq 'dlvhdr/gh-dash' && \
-			printf '%s\n' "$$output" | grep -Fq 'babarot/gh-infra'; \
-	}; \
-	run_check "Homebrew dependencies" brew bundle check --verbose --file=Brewfile; \
-	run_check "Stow links" check_stow; \
-	run_check "zsh syntax" zsh -n packages/zsh/.zshrc; \
-	run_check "mise installation" mise doctor; \
-	run_check "GitHub CLI extensions" check_gh_extensions; \
-	run_check "GitAlias" test -f "$$HOME/.git-extensions/gitalias.txt"; \
-	run_check "Vim plugins" test -d "$$HOME/.vim/pack/themes/start/iceberg.vim"; \
-	run_check "bat theme cache" sh -c 'bat --list-themes | grep -Fxq Iceberg'; \
-	printf '\n'; \
-	if [ "$$status" -eq 0 ]; then \
-		printf 'All checks passed.\n'; \
-	else \
-		printf 'One or more checks failed.\n' >&2; \
-	fi; \
-	exit "$$status"
+	@./scripts/doctor.sh $(PACKAGES)

--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ CODEX_SHARED_CONFIG := config/codex/config.toml
 CODEX_SYSTEM_CONFIG ?= /etc/codex/config.toml
 CODEX_CONFIG_SUDO ?= sudo
 
-.PHONY: help install _install update doctor \
+.PHONY: help test install _install update doctor \
 	brew-install brew-update brewfile-dump brew-prune \
 	stow-link stow-unlink _clean-legacy-claude-skills-stow \
 	mise-install skills-install skills-update \
@@ -37,6 +37,9 @@ CODEX_CONFIG_SUDO ?= sudo
 
 help: ## 利用可能なタスク一覧を表示
 	@awk 'BEGIN {FS = ":.*## "; count = 0} /^[a-zA-Z][a-zA-Z0-9_-]*:.*## / {names[count] = $$1; descriptions[count] = $$2; if (length($$1) > width) width = length($$1); count++} END {for (i = 0; i < count; i++) printf "\033[36m%-*s\033[0m %s\n", width + 2, names[i], descriptions[i]}' $(MAKEFILE_LIST)
+
+test: ## Shell script のテストを実行
+	./tests/shell-scripts.sh
 
 install: ## dotfiles 環境を初回セットアップ
 	./install.sh

--- a/scripts/codex-system-config.sh
+++ b/scripts/codex-system-config.sh
@@ -1,0 +1,146 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+: "${CODEX_SHARED_CONFIG:?CODEX_SHARED_CONFIG is required}"
+: "${CODEX_SYSTEM_CONFIG:?CODEX_SYSTEM_CONFIG is required}"
+
+CODEX_CONFIG_SUDO=${CODEX_CONFIG_SUDO-sudo}
+
+privileged() {
+  if [ -n "$CODEX_CONFIG_SUDO" ]; then
+    # Preserve Makefile's support for a command plus fixed arguments.
+    # shellcheck disable=SC2086
+    $CODEX_CONFIG_SUDO "$@"
+  else
+    "$@"
+  fi
+}
+
+reject_destination_symlink() {
+  if privileged test -L "$CODEX_SYSTEM_CONFIG"; then
+    printf '%s\n' "symlink は自動処理しません: $CODEX_SYSTEM_CONFIG" >&2
+    exit 1
+  fi
+}
+
+dry_run() {
+  local tmp_file
+  umask 077
+  reject_destination_symlink
+  if privileged test -e "$CODEX_SYSTEM_CONFIG"; then
+    tmp_file=$(mktemp)
+    trap 'rm -f "$tmp_file"' EXIT HUP INT TERM
+    privileged cat "$CODEX_SYSTEM_CONFIG" >"$tmp_file"
+    if cmp -s "$tmp_file" "$CODEX_SHARED_CONFIG"; then
+      printf '%s\n' "変更はありません: $CODEX_SYSTEM_CONFIG"
+    else
+      printf '%s\n' "適用予定の差分: $CODEX_SYSTEM_CONFIG"
+      diff -u "$tmp_file" "$CODEX_SHARED_CONFIG" || true
+    fi
+    rm -f "$tmp_file"
+    trap - EXIT HUP INT TERM
+  else
+    printf '%s\n' "新規作成予定: $CODEX_SYSTEM_CONFIG"
+    sed -n '1,$p' "$CODEX_SHARED_CONFIG"
+  fi
+}
+
+install_config() {
+  local destination_dir tmp_file current_file answer
+  umask 077
+  destination_dir=$(dirname "$CODEX_SYSTEM_CONFIG")
+  tmp_file=''
+  current_file=''
+  cleanup_install() {
+    [ -z "$current_file" ] || rm -f "$current_file"
+    [ -z "$tmp_file" ] || privileged rm -f "$tmp_file"
+  }
+  trap cleanup_install EXIT HUP INT TERM
+
+  reject_destination_symlink
+  if privileged test -e "$CODEX_SYSTEM_CONFIG"; then
+    current_file=$(mktemp)
+    privileged cat "$CODEX_SYSTEM_CONFIG" >"$current_file"
+    if cmp -s "$current_file" "$CODEX_SHARED_CONFIG"; then
+      rm -f "$current_file"
+      current_file=''
+      printf '%s\n' "既に最新です: $CODEX_SYSTEM_CONFIG"
+      trap - EXIT HUP INT TERM
+      return
+    fi
+    rm -f "$current_file"
+    current_file=''
+    printf '既存の %s を上記内容で更新しますか? [y/N] ' "$CODEX_SYSTEM_CONFIG"
+    read -r answer
+    case "$answer" in y | Y) ;; *) printf '%s\n' '更新を中止しました。'; return 1 ;; esac
+  fi
+
+  privileged install -d -m 0755 "$destination_dir"
+  reject_destination_symlink
+  tmp_file=$(privileged mktemp "$destination_dir/.config.toml.install.XXXXXX")
+  privileged install -m 0644 "$CODEX_SHARED_CONFIG" "$tmp_file"
+  if privileged test -L "$tmp_file" || ! privileged test -f "$tmp_file"; then
+    printf '%s\n' "一時ファイルが通常ファイルではありません: $tmp_file" >&2
+    exit 1
+  fi
+  reject_destination_symlink
+  privileged mv -fh "$tmp_file" "$CODEX_SYSTEM_CONFIG"
+  tmp_file=''
+  trap - EXIT HUP INT TERM
+  printf '%s\n' "導入しました: $CODEX_SYSTEM_CONFIG"
+}
+
+check_config() {
+  local tmp_dir report
+  tmp_dir=$(mktemp -d)
+  trap 'rm -rf "$tmp_dir"' EXIT HUP INT TERM
+  cp "$CODEX_SHARED_CONFIG" "$tmp_dir/config.toml"
+  report="$tmp_dir/doctor.json"
+  CODEX_HOME="$tmp_dir" codex doctor --json >"$report" || true
+  jq -e '
+    .checks["config.load"].status == "ok" and
+    (.checks["config.load"].details["feature flag overrides"] | contains("runtime_metrics=true")) and
+    .checks["sandbox.helpers"].details["approval policy"] == "OnRequest" and
+    .checks["sandbox.helpers"].details["filesystem sandbox"] == "unrestricted"
+  ' "$report" >/dev/null
+  rm -rf "$tmp_dir"
+  trap - EXIT HUP INT TERM
+  printf '%s\n' '共有Codex設定の読み込みと代表値を確認しました。'
+}
+
+verify_config() {
+  local tmp_dir
+  if privileged test -L "$CODEX_SYSTEM_CONFIG" || ! privileged test -f "$CODEX_SYSTEM_CONFIG"; then
+    printf '%s\n' "system config が通常ファイルとして導入されていません: $CODEX_SYSTEM_CONFIG" >&2
+    exit 1
+  fi
+  if ! privileged cmp -s "$CODEX_SHARED_CONFIG" "$CODEX_SYSTEM_CONFIG"; then
+    printf '%s\n' "system config が共有設定の正本と一致しません: $CODEX_SYSTEM_CONFIG" >&2
+    exit 1
+  fi
+  tmp_dir=$(mktemp -d)
+  trap 'rm -rf "$tmp_dir"' EXIT HUP INT TERM
+  mkdir "$tmp_dir/expected-home" "$tmp_dir/actual-home"
+  cp "$CODEX_SHARED_CONFIG" "$tmp_dir/expected-home/config.toml"
+  CODEX_HOME="$tmp_dir/expected-home" codex doctor --json >"$tmp_dir/expected.json" || true
+  CODEX_HOME="$tmp_dir/actual-home" codex doctor --json >"$tmp_dir/actual.json" || true
+  jq -e --slurpfile expected "$tmp_dir/expected.json" '
+    .checks["config.load"].status == "ok" and
+    .checks["config.load"].details.model == $expected[0].checks["config.load"].details.model and
+    .checks["config.load"].details["feature flag overrides"] == $expected[0].checks["config.load"].details["feature flag overrides"] and
+    .checks["sandbox.helpers"].details["approval policy"] == $expected[0].checks["sandbox.helpers"].details["approval policy"] and
+    .checks["sandbox.helpers"].details["filesystem sandbox"] == $expected[0].checks["sandbox.helpers"].details["filesystem sandbox"]
+  ' "$tmp_dir/actual.json" >/dev/null
+  rm -rf "$tmp_dir"
+  trap - EXIT HUP INT TERM
+  printf '%s\n' '有効なCodex設定の代表値を確認しました。'
+}
+
+case "${1-}" in
+  dry-run) dry_run ;;
+  install) install_config ;;
+  check) check_config ;;
+  verify) verify_config ;;
+  *) printf 'Usage: %s {dry-run|install|check|verify}\n' "$0" >&2; exit 2 ;;
+esac

--- a/scripts/codex-system-config.sh
+++ b/scripts/codex-system-config.sh
@@ -7,6 +7,9 @@ set -euo pipefail
 
 CODEX_CONFIG_SUDO=${CODEX_CONFIG_SUDO-sudo}
 
+cleanup_local_path=''
+cleanup_privileged_path=''
+
 privileged() {
   if [ -n "$CODEX_CONFIG_SUDO" ]; then
     # Preserve Makefile's support for a command plus fixed arguments.
@@ -17,6 +20,25 @@ privileged() {
   fi
 }
 
+cleanup_on_exit() {
+  local status=$?
+  trap - EXIT
+  set +e
+  [ -z "$cleanup_local_path" ] || rm -rf "$cleanup_local_path"
+  [ -z "$cleanup_privileged_path" ] || privileged rm -f "$cleanup_privileged_path"
+  exit "$status"
+}
+
+exit_on_signal() {
+  local status=$1
+  exit "$status"
+}
+
+trap cleanup_on_exit EXIT
+trap 'exit_on_signal 129' HUP
+trap 'exit_on_signal 130' INT
+trap 'exit_on_signal 143' TERM
+
 reject_destination_symlink() {
   if privileged test -L "$CODEX_SYSTEM_CONFIG"; then
     printf '%s\n' "symlink は自動処理しません: $CODEX_SYSTEM_CONFIG" >&2
@@ -25,21 +47,19 @@ reject_destination_symlink() {
 }
 
 dry_run() {
-  local tmp_file
   umask 077
   reject_destination_symlink
   if privileged test -e "$CODEX_SYSTEM_CONFIG"; then
-    tmp_file=$(mktemp)
-    trap 'rm -f "$tmp_file"' EXIT HUP INT TERM
-    privileged cat "$CODEX_SYSTEM_CONFIG" >"$tmp_file"
-    if cmp -s "$tmp_file" "$CODEX_SHARED_CONFIG"; then
+    cleanup_local_path=$(mktemp)
+    privileged cat "$CODEX_SYSTEM_CONFIG" >"$cleanup_local_path"
+    if cmp -s "$cleanup_local_path" "$CODEX_SHARED_CONFIG"; then
       printf '%s\n' "変更はありません: $CODEX_SYSTEM_CONFIG"
     else
       printf '%s\n' "適用予定の差分: $CODEX_SYSTEM_CONFIG"
-      diff -u "$tmp_file" "$CODEX_SHARED_CONFIG" || true
+      diff -u "$cleanup_local_path" "$CODEX_SHARED_CONFIG" || true
     fi
-    rm -f "$tmp_file"
-    trap - EXIT HUP INT TERM
+    rm -f "$cleanup_local_path"
+    cleanup_local_path=''
   else
     printf '%s\n' "新規作成予定: $CODEX_SYSTEM_CONFIG"
     sed -n '1,$p' "$CODEX_SHARED_CONFIG"
@@ -47,30 +67,22 @@ dry_run() {
 }
 
 install_config() {
-  local destination_dir tmp_file current_file answer
+  local destination_dir answer
   umask 077
   destination_dir=$(dirname "$CODEX_SYSTEM_CONFIG")
-  tmp_file=''
-  current_file=''
-  cleanup_install() {
-    [ -z "$current_file" ] || rm -f "$current_file"
-    [ -z "$tmp_file" ] || privileged rm -f "$tmp_file"
-  }
-  trap cleanup_install EXIT HUP INT TERM
 
   reject_destination_symlink
   if privileged test -e "$CODEX_SYSTEM_CONFIG"; then
-    current_file=$(mktemp)
-    privileged cat "$CODEX_SYSTEM_CONFIG" >"$current_file"
-    if cmp -s "$current_file" "$CODEX_SHARED_CONFIG"; then
-      rm -f "$current_file"
-      current_file=''
+    cleanup_local_path=$(mktemp)
+    privileged cat "$CODEX_SYSTEM_CONFIG" >"$cleanup_local_path"
+    if cmp -s "$cleanup_local_path" "$CODEX_SHARED_CONFIG"; then
+      rm -f "$cleanup_local_path"
+      cleanup_local_path=''
       printf '%s\n' "既に最新です: $CODEX_SYSTEM_CONFIG"
-      trap - EXIT HUP INT TERM
       return
     fi
-    rm -f "$current_file"
-    current_file=''
+    rm -f "$cleanup_local_path"
+    cleanup_local_path=''
     printf '既存の %s を上記内容で更新しますか? [y/N] ' "$CODEX_SYSTEM_CONFIG"
     read -r answer
     case "$answer" in y | Y) ;; *) printf '%s\n' '更新を中止しました。'; return 1 ;; esac
@@ -78,39 +90,36 @@ install_config() {
 
   privileged install -d -m 0755 "$destination_dir"
   reject_destination_symlink
-  tmp_file=$(privileged mktemp "$destination_dir/.config.toml.install.XXXXXX")
-  privileged install -m 0644 "$CODEX_SHARED_CONFIG" "$tmp_file"
-  if privileged test -L "$tmp_file" || ! privileged test -f "$tmp_file"; then
-    printf '%s\n' "一時ファイルが通常ファイルではありません: $tmp_file" >&2
+  cleanup_privileged_path=$(privileged mktemp "$destination_dir/.config.toml.install.XXXXXX")
+  privileged install -m 0644 "$CODEX_SHARED_CONFIG" "$cleanup_privileged_path"
+  if privileged test -L "$cleanup_privileged_path" || ! privileged test -f "$cleanup_privileged_path"; then
+    printf '%s\n' "一時ファイルが通常ファイルではありません: $cleanup_privileged_path" >&2
     exit 1
   fi
   reject_destination_symlink
-  privileged mv -fh "$tmp_file" "$CODEX_SYSTEM_CONFIG"
-  tmp_file=''
-  trap - EXIT HUP INT TERM
+  privileged mv -fh "$cleanup_privileged_path" "$CODEX_SYSTEM_CONFIG"
+  cleanup_privileged_path=''
   printf '%s\n' "導入しました: $CODEX_SYSTEM_CONFIG"
 }
 
 check_config() {
-  local tmp_dir report
-  tmp_dir=$(mktemp -d)
-  trap 'rm -rf "$tmp_dir"' EXIT HUP INT TERM
-  cp "$CODEX_SHARED_CONFIG" "$tmp_dir/config.toml"
-  report="$tmp_dir/doctor.json"
-  CODEX_HOME="$tmp_dir" codex doctor --json >"$report" || true
+  local report
+  cleanup_local_path=$(mktemp -d)
+  cp "$CODEX_SHARED_CONFIG" "$cleanup_local_path/config.toml"
+  report="$cleanup_local_path/doctor.json"
+  CODEX_HOME="$cleanup_local_path" codex doctor --json >"$report" || true
   jq -e '
     .checks["config.load"].status == "ok" and
     (.checks["config.load"].details["feature flag overrides"] | contains("runtime_metrics=true")) and
     .checks["sandbox.helpers"].details["approval policy"] == "OnRequest" and
     .checks["sandbox.helpers"].details["filesystem sandbox"] == "unrestricted"
   ' "$report" >/dev/null
-  rm -rf "$tmp_dir"
-  trap - EXIT HUP INT TERM
+  rm -rf "$cleanup_local_path"
+  cleanup_local_path=''
   printf '%s\n' '共有Codex設定の読み込みと代表値を確認しました。'
 }
 
 verify_config() {
-  local tmp_dir
   if privileged test -L "$CODEX_SYSTEM_CONFIG" || ! privileged test -f "$CODEX_SYSTEM_CONFIG"; then
     printf '%s\n' "system config が通常ファイルとして導入されていません: $CODEX_SYSTEM_CONFIG" >&2
     exit 1
@@ -119,21 +128,20 @@ verify_config() {
     printf '%s\n' "system config が共有設定の正本と一致しません: $CODEX_SYSTEM_CONFIG" >&2
     exit 1
   fi
-  tmp_dir=$(mktemp -d)
-  trap 'rm -rf "$tmp_dir"' EXIT HUP INT TERM
-  mkdir "$tmp_dir/expected-home" "$tmp_dir/actual-home"
-  cp "$CODEX_SHARED_CONFIG" "$tmp_dir/expected-home/config.toml"
-  CODEX_HOME="$tmp_dir/expected-home" codex doctor --json >"$tmp_dir/expected.json" || true
-  CODEX_HOME="$tmp_dir/actual-home" codex doctor --json >"$tmp_dir/actual.json" || true
-  jq -e --slurpfile expected "$tmp_dir/expected.json" '
+  cleanup_local_path=$(mktemp -d)
+  mkdir "$cleanup_local_path/expected-home" "$cleanup_local_path/actual-home"
+  cp "$CODEX_SHARED_CONFIG" "$cleanup_local_path/expected-home/config.toml"
+  CODEX_HOME="$cleanup_local_path/expected-home" codex doctor --json >"$cleanup_local_path/expected.json" || true
+  CODEX_HOME="$cleanup_local_path/actual-home" codex doctor --json >"$cleanup_local_path/actual.json" || true
+  jq -e --slurpfile expected "$cleanup_local_path/expected.json" '
     .checks["config.load"].status == "ok" and
     .checks["config.load"].details.model == $expected[0].checks["config.load"].details.model and
     .checks["config.load"].details["feature flag overrides"] == $expected[0].checks["config.load"].details["feature flag overrides"] and
     .checks["sandbox.helpers"].details["approval policy"] == $expected[0].checks["sandbox.helpers"].details["approval policy"] and
     .checks["sandbox.helpers"].details["filesystem sandbox"] == $expected[0].checks["sandbox.helpers"].details["filesystem sandbox"]
-  ' "$tmp_dir/actual.json" >/dev/null
-  rm -rf "$tmp_dir"
-  trap - EXIT HUP INT TERM
+  ' "$cleanup_local_path/actual.json" >/dev/null
+  rm -rf "$cleanup_local_path"
+  cleanup_local_path=''
   printf '%s\n' '有効なCodex設定の代表値を確認しました。'
 }
 

--- a/scripts/doctor.sh
+++ b/scripts/doctor.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+status=0
+packages=("$@")
+
+run_check() {
+  local name
+  name=$1
+  shift
+  printf '\n==> %s\n' "$name"
+  if "$@"; then
+    printf '[PASS] %s\n' "$name"
+  else
+    printf '[FAIL] %s\n' "$name" >&2
+    status=1
+  fi
+}
+
+# Functions below are passed by name to run_check.
+# shellcheck disable=SC2329
+check_stow() {
+  local output stow_status
+  set +e
+  output=$(stow --simulate --verbose --no-folding --dir=packages --target="$HOME" "${packages[@]}" 2>&1)
+  stow_status=$?
+  set -e
+  [ -z "$output" ] || printf '%s\n' "$output"
+  [ "$stow_status" -eq 0 ] || return "$stow_status"
+  if printf '%s\n' "$output" | grep -Eq '^(LINK|MKDIR):'; then
+    printf 'Stow would create links or directories.\n' >&2
+    return 1
+  fi
+}
+
+# shellcheck disable=SC2329
+check_gh_extensions() {
+  local output
+  output=$(gh extension list)
+  printf '%s\n' "$output" | grep -Fq 'dlvhdr/gh-dash' &&
+    printf '%s\n' "$output" | grep -Fq 'babarot/gh-infra'
+}
+
+run_check "Homebrew dependencies" brew bundle check --verbose --file=Brewfile
+run_check "Stow links" check_stow
+run_check "zsh syntax" zsh -n packages/zsh/.zshrc
+run_check "mise installation" mise doctor
+run_check "GitHub CLI extensions" check_gh_extensions
+run_check "GitAlias" test -f "$HOME/.git-extensions/gitalias.txt"
+run_check "Vim plugins" test -d "$HOME/.vim/pack/themes/start/iceberg.vim"
+run_check "bat theme cache" sh -c 'bat --list-themes | grep -Fxq Iceberg'
+
+printf '\n'
+if [ "$status" -eq 0 ]; then
+  printf 'All checks passed.\n'
+else
+  printf 'One or more checks failed.\n' >&2
+fi
+exit "$status"

--- a/scripts/skills-install.sh
+++ b/scripts/skills-install.sh
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+: "${AGENT_SKILLS_DIR:?AGENT_SKILLS_DIR is required}"
+: "${CLAUDE_SKILLS_DIR:?CLAUDE_SKILLS_DIR is required}"
+: "${CODEX_SKILLS_DIR:?CODEX_SKILLS_DIR is required}"
+
+is_managed_skill() {
+  local skill_file_path expected_repository expected_skill_path
+  skill_file_path="$1/SKILL.md"
+  expected_repository="https://github.com/$2"
+  expected_skill_path="skills/$3"
+  [ -f "$skill_file_path" ] || return 1
+  awk -v expected_repository="$expected_repository" -v expected_skill_path="$expected_skill_path" '
+    NR == 1 { if ($0 != "---") exit 1; frontmatter = 1; next }
+    frontmatter && $0 == "---" {
+      closed = 1
+      valid_sha = length(tree_sha) == 40 && tree_sha !~ /[^0-9a-f]/
+      exit !(metadata_count == 1 && !invalid_metadata && repo_count == 1 && path_count == 1 && sha_count == 1 && repository == expected_repository && skill_path == expected_skill_path && valid_sha)
+    }
+    frontmatter && $0 == "metadata:" { metadata = 1; metadata_count++; next }
+    metadata && /^[^[:space:]]/ { metadata = 0 }
+    metadata && /^  [^ ]/ { invalid_metadata = 1; metadata = 0 }
+    metadata && /^    github-repo:[[:space:]]*/ { repo_count++; repository = $0; sub(/^    github-repo:[[:space:]]*/, "", repository); next }
+    metadata && /^    github-path:[[:space:]]*/ { path_count++; skill_path = $0; sub(/^    github-path:[[:space:]]*/, "", skill_path); next }
+    metadata && /^    github-tree-sha:[[:space:]]*/ { sha_count++; tree_sha = $0; sub(/^    github-tree-sha:[[:space:]]*/, "", tree_sha); next }
+    END { if (!closed) exit 1 }
+  ' "$skill_file_path" >/dev/null
+}
+
+mkdir -p "$AGENT_SKILLS_DIR" "$CLAUDE_SKILLS_DIR"
+
+for skill_spec in "$@"; do
+  repository=${skill_spec%:*}
+  skill=${skill_spec#*:}
+  canonical_path="$AGENT_SKILLS_DIR/$skill"
+  claude_path="$CLAUDE_SKILLS_DIR/$skill"
+  codex_path="$CODEX_SKILLS_DIR/$skill"
+
+  if [ -L "$canonical_path" ]; then
+    if is_managed_skill "$canonical_path" "$repository" "$skill"; then
+      rm -f "$canonical_path"
+    else
+      printf '%s\n' "管理外の symlink と競合しています: $canonical_path" >&2
+      exit 1
+    fi
+  elif [ -e "$canonical_path" ] && ! is_managed_skill "$canonical_path" "$repository" "$skill"; then
+    printf '%s\n' "管理外の既存 skill と競合しています: $canonical_path" >&2
+    exit 1
+  fi
+
+  gh skill install "$repository" "$skill" --dir "$AGENT_SKILLS_DIR" -f
+
+  if [ -L "$claude_path" ]; then
+    target=$(readlink "$claude_path")
+    if [ "$claude_path" -ef "$canonical_path" ]; then
+      :
+    elif [ ! -e "$claude_path" ]; then
+      printf '%s\n' "既存の壊れた外部 symlink を保持します: $claude_path -> $target"
+    elif is_managed_skill "$claude_path" "$repository" "$skill"; then
+      rm -f "$claude_path"
+    else
+      printf '%s\n' "既存の外部 symlink を保持します: $claude_path -> $target"
+    fi
+  elif [ -e "$claude_path" ]; then
+    if is_managed_skill "$claude_path" "$repository" "$skill"; then
+      rm -rf "$claude_path"
+    else
+      printf '%s\n' "管理外の既存 skill を保持します: $claude_path"
+    fi
+  fi
+
+  if [ ! -e "$claude_path" ] && [ ! -L "$claude_path" ]; then
+    if [ "$AGENT_SKILLS_DIR" = "$HOME/.agents/skills" ] && [ "$CLAUDE_SKILLS_DIR" = "$HOME/.claude/skills" ]; then
+      link_target="../../.agents/skills/$skill"
+    else
+      link_target="$canonical_path"
+    fi
+    ln -s "$link_target" "$claude_path"
+  fi
+
+  if [ -L "$codex_path" ]; then
+    target=$(readlink "$codex_path")
+    if [ -e "$codex_path" ] && { [ "$codex_path" -ef "$canonical_path" ] || is_managed_skill "$codex_path" "$repository" "$skill"; }; then
+      rm -f "$codex_path"
+    else
+      printf '%s\n' "既存の外部 symlink を保持します: $codex_path -> $target"
+    fi
+  elif [ -e "$codex_path" ]; then
+    if is_managed_skill "$codex_path" "$repository" "$skill"; then
+      rm -rf "$codex_path"
+    else
+      printf '%s\n' "管理外の既存 skill を保持します: $codex_path"
+    fi
+  fi
+done

--- a/tests/shell-scripts.sh
+++ b/tests/shell-scripts.sh
@@ -71,7 +71,7 @@ EOF
 }
 
 test_codex_system_config() {
-  local case_dir source destination output target
+  local case_dir source destination missing_source output target
   case_dir="$test_root/codex"
   source="$case_dir/shared.toml"
   destination="$case_dir/etc/config.toml"
@@ -105,6 +105,20 @@ test_codex_system_config() {
   fi
   assert_contains "$output" 'symlink は自動処理しません'
   [ "$(cat "$target")" = 'do not change' ] || fail 'symlink target was modified'
+
+  rm -f "$destination"
+  missing_source="$case_dir/missing.toml"
+  if output=$(PATH="$bin_dir:$PATH" CODEX_SHARED_CONFIG="$missing_source" \
+    CODEX_SYSTEM_CONFIG="$destination" CODEX_CONFIG_SUDO='' \
+    "$repo_root/scripts/codex-system-config.sh" install 2>&1); then
+    fail 'install with a missing source was accepted'
+  fi
+  case "$output" in
+    *'unbound variable'*) fail 'cleanup replaced the original install error' ;;
+  esac
+  if find "$(dirname "$destination")" -name '.config.toml.install.*' -print -quit | grep -q .; then
+    fail 'failed install left a temporary file behind'
+  fi
 }
 
 write_doctor_mocks() {

--- a/tests/shell-scripts.sh
+++ b/tests/shell-scripts.sh
@@ -1,0 +1,152 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+repo_root=$(cd "$(dirname "$0")/.." && pwd)
+test_root=$(mktemp -d)
+trap 'rm -rf "$test_root"' EXIT HUP INT TERM
+bin_dir="$test_root/bin"
+mkdir -p "$bin_dir"
+
+fail() {
+  printf 'FAIL: %s\n' "$1" >&2
+  exit 1
+}
+
+assert_contains() {
+  case "$1" in *"$2"*) ;; *) fail "expected output to contain: $2" ;; esac
+}
+
+test_skills_install() {
+  local home output
+  home="$test_root/skills-home"
+  mkdir -p "$home/.codex/skills"
+  cat >"$bin_dir/gh" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+repository=$3
+skill=$4
+directory=$6
+mkdir -p "$directory/$skill"
+cat >"$directory/$skill/SKILL.md" <<SKILL
+---
+metadata:
+    github-repo: https://github.com/$repository
+    github-path: skills/$skill
+    github-tree-sha: 0123456789abcdef0123456789abcdef01234567
+---
+SKILL
+EOF
+  chmod +x "$bin_dir/gh"
+
+  make -s -C "$repo_root" skills-install \
+    HOME="$home" PATH="$bin_dir:$PATH" \
+    AGENT_SKILLS='owner/repo:example' \
+    AGENT_SKILLS_DIR="$home/.agents/skills" \
+    CLAUDE_SKILLS_DIR="$home/.claude/skills" \
+    CODEX_SKILLS_DIR="$home/.codex/skills"
+  [ -f "$home/.agents/skills/example/SKILL.md" ] || fail 'skill was not installed'
+  [ -L "$home/.claude/skills/example" ] || fail 'Claude skill link was not created'
+
+  mkdir -p "$home/.agents/skills/unmanaged"
+  printf 'unmanaged\n' >"$home/.agents/skills/unmanaged/SKILL.md"
+  if output=$(HOME="$home" PATH="$bin_dir:$PATH" \
+    AGENT_SKILLS_DIR="$home/.agents/skills" \
+    CLAUDE_SKILLS_DIR="$home/.claude/skills" \
+    CODEX_SKILLS_DIR="$home/.codex/skills" \
+    "$repo_root/scripts/skills-install.sh" owner/repo:unmanaged 2>&1); then
+    fail 'unmanaged skill collision was accepted'
+  fi
+  assert_contains "$output" '管理外の既存 skill と競合しています'
+}
+
+write_fake_codex() {
+  cat >"$bin_dir/codex" <<'EOF'
+#!/usr/bin/env bash
+cat <<'JSON'
+{"checks":{"config.load":{"status":"ok","details":{"model":"test-model","feature flag overrides":"runtime_metrics=true"}},"sandbox.helpers":{"details":{"approval policy":"OnRequest","filesystem sandbox":"unrestricted"}}}}
+JSON
+EOF
+  chmod +x "$bin_dir/codex"
+}
+
+test_codex_system_config() {
+  local case_dir source destination output target
+  case_dir="$test_root/codex"
+  source="$case_dir/shared.toml"
+  destination="$case_dir/etc/config.toml"
+  mkdir -p "$case_dir"
+  printf 'model = "test"\n' >"$source"
+  write_fake_codex
+
+  output=$(PATH="$bin_dir:$PATH" CODEX_SHARED_CONFIG="$source" \
+    CODEX_SYSTEM_CONFIG="$destination" CODEX_CONFIG_SUDO='' \
+    "$repo_root/scripts/codex-system-config.sh" dry-run)
+  assert_contains "$output" '新規作成予定'
+  make -s -C "$repo_root" codex-system-config-install \
+    PATH="$bin_dir:$PATH" CODEX_SHARED_CONFIG="$source" \
+    CODEX_SYSTEM_CONFIG="$destination" CODEX_CONFIG_SUDO='' >/dev/null
+  cmp -s "$source" "$destination" || fail 'system config was not installed'
+  PATH="$bin_dir:$PATH" CODEX_SHARED_CONFIG="$source" \
+    CODEX_SYSTEM_CONFIG="$destination" CODEX_CONFIG_SUDO='' \
+    "$repo_root/scripts/codex-system-config.sh" check >/dev/null
+  PATH="$bin_dir:$PATH" CODEX_SHARED_CONFIG="$source" \
+    CODEX_SYSTEM_CONFIG="$destination" CODEX_CONFIG_SUDO='' \
+    "$repo_root/scripts/codex-system-config.sh" verify >/dev/null
+
+  target="$case_dir/symlink-target.toml"
+  printf 'do not change\n' >"$target"
+  rm -f "$destination"
+  ln -s "$target" "$destination"
+  if output=$(PATH="$bin_dir:$PATH" CODEX_SHARED_CONFIG="$source" \
+    CODEX_SYSTEM_CONFIG="$destination" CODEX_CONFIG_SUDO='' \
+    "$repo_root/scripts/codex-system-config.sh" install 2>&1); then
+    fail 'system config symlink was accepted'
+  fi
+  assert_contains "$output" 'symlink は自動処理しません'
+  [ "$(cat "$target")" = 'do not change' ] || fail 'symlink target was modified'
+}
+
+write_doctor_mocks() {
+  local command
+  for command in brew zsh mise; do
+    cat >"$bin_dir/$command" <<'EOF'
+#!/usr/bin/env bash
+exit 0
+EOF
+    chmod +x "$bin_dir/$command"
+  done
+  cat >"$bin_dir/bat" <<'EOF'
+#!/usr/bin/env bash
+printf '%s\n' Iceberg
+EOF
+  cat >"$bin_dir/gh" <<'EOF'
+#!/usr/bin/env bash
+printf '%s\n' 'dlvhdr/gh-dash' 'babarot/gh-infra'
+EOF
+  cat >"$bin_dir/stow" <<'EOF'
+#!/usr/bin/env bash
+[ "${STOW_CHANGES-}" != 1 ] || printf '%s\n' 'LINK: .example'
+EOF
+  chmod +x "$bin_dir/bat" "$bin_dir/gh" "$bin_dir/stow"
+}
+
+test_doctor() {
+  local home output
+  home="$test_root/doctor-home"
+  mkdir -p "$home/.git-extensions" "$home/.vim/pack/themes/start/iceberg.vim"
+  : >"$home/.git-extensions/gitalias.txt"
+  write_doctor_mocks
+
+  output=$(make -s -C "$repo_root" doctor HOME="$home" PATH="$bin_dir:$PATH" PACKAGES=zsh)
+  assert_contains "$output" 'All checks passed.'
+  if output=$(cd "$repo_root" && HOME="$home" PATH="$bin_dir:$PATH" STOW_CHANGES=1 ./scripts/doctor.sh zsh 2>&1); then
+    fail 'doctor accepted pending Stow changes'
+  fi
+  assert_contains "$output" '[FAIL] Stow links'
+}
+
+test_skills_install
+test_codex_system_config
+test_doctor
+printf 'All shell script tests passed.\n'

--- a/tests/shell-scripts.sh
+++ b/tests/shell-scripts.sh
@@ -4,7 +4,10 @@ set -euo pipefail
 
 repo_root=$(cd "$(dirname "$0")/.." && pwd)
 test_root=$(mktemp -d)
-trap 'rm -rf "$test_root"' EXIT HUP INT TERM
+trap 'rm -rf "$test_root"' EXIT
+trap 'exit 129' HUP
+trap 'exit 130' INT
+trap 'exit 143' TERM
 bin_dir="$test_root/bin"
 mkdir -p "$bin_dir"
 


### PR DESCRIPTION
close #384

## 目的

Makefile に埋め込まれていた複雑なシェル処理を専用スクリプトへ分離し、可読性・保守性・テスト容易性を改善します。既存の機能と仕様は維持したまま、抽出した処理をシェルテストで検証できる構成にします。

## 影響パス

- `Makefile`
- `.github/workflows/test.yml`
- `scripts/codex-system-config.sh`
- `scripts/doctor.sh`
- `scripts/skills-install.sh`
- `tests/shell-scripts.sh`

## 主な変更

- Codex system config、doctor、skills install の処理を Makefile から Shell Script へ抽出
- 抽出したスクリプトの正常系・異常系・シグナル処理を検証するテストを追加
- `.github/workflows/test.yml` に macOS の Test job を追加し、macOS 標準 Bash を含む実行環境で `make test` を継続検証
- レビュー指摘に基づく堅牢性とエラーハンドリングの改善

## 検証

- `make test`
- `make help`
- ShellCheck
- `npx prettier@3 --check .`
- `git diff --check`
