### PR TITLE
refactor: pre-commitをgitleaks中心に整理し品質チェックをCIへ寄せる

### DIFF
--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -1,0 +1,34 @@
+name: Gitleaks
+
+on:
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+env:
+  GITLEAKS_VERSION: "8.30.1"
+  GITLEAKS_SHA256: "551f6fc83ea457d62a0d98237cbad105af8d557003051f41f3e7ca7b3f2470eb"
+
+jobs:
+  gitleaks:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - name: Install Gitleaks
+        run: |
+          archive="$RUNNER_TEMP/gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz"
+          curl -sSfL "https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz" \
+            -o "$archive"
+          printf '%s  %s\n' "$GITLEAKS_SHA256" "$archive" | sha256sum --check
+          tar -xzf "$archive" -C "$RUNNER_TEMP" gitleaks
+          printf '%s\n' "$RUNNER_TEMP" >>"$GITHUB_PATH"
+      - name: Verify Gitleaks version
+        run: test "$(gitleaks version)" = "$GITLEAKS_VERSION"
+      - name: Scan Git history
+        run: gitleaks git --redact --verbose
+      - name: Test global pre-commit hook
+        run: ./tests/gitleaks-pre-commit.sh

--- a/packages/git/.git-hooks/pre-commit
+++ b/packages/git/.git-hooks/pre-commit
@@ -6,22 +6,10 @@ if ! command -v gitleaks &>/dev/null; then
     exit 1
 fi
 
-gitleaks protect --staged --no-banner
+gitleaks git --pre-commit --redact --staged --verbose
 
 # Delegate to repo-local pre-commit hook so per-repo hooks (husky, lefthook, etc.) still run
 local_hook="$(git rev-parse --git-dir)/hooks/pre-commit"
 if [ -x "$local_hook" ]; then
     "$local_hook"
-fi
-
-# Run ShellCheck on staged .sh files (NUL-safe for paths with spaces)
-if command -v shellcheck &>/dev/null; then
-    while IFS= read -r -d '' file; do
-        case "$file" in *.sh) shellcheck "$file" ;; esac
-    done < <(git diff --cached --name-only -z --diff-filter=ACMR)
-else
-    if git diff --cached --name-only --diff-filter=ACMR | grep -q '\.sh$'; then
-        echo "Warning: shellcheck is not installed. Skipping shell script check."
-        echo "Install with: brew install shellcheck"
-    fi
 fi

--- a/tests/gitleaks-pre-commit.sh
+++ b/tests/gitleaks-pre-commit.sh
@@ -49,4 +49,12 @@ esac
 git -C "$test_root/repository" diff --cached --quiet -- secret.txt && \
   fail 'rejected secret was not left staged'
 
+git -C "$test_root/repository" commit --no-verify -q -m 'test: bypass hook'
+if output=$(gitleaks git --redact --verbose "$test_root/repository" 2>&1); then
+  fail 'git history scan accepted a committed dummy secret'
+fi
+case "$output" in
+  *"$dummy_secret"*) fail 'git history scan output exposed the detected secret' ;;
+esac
+
 printf 'Gitleaks pre-commit hook tests passed.\n'

--- a/tests/gitleaks-pre-commit.sh
+++ b/tests/gitleaks-pre-commit.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+repo_root=$(cd "$(dirname "$0")/.." && pwd)
+hook_path="$repo_root/packages/git/.git-hooks"
+test_root=$(mktemp -d)
+trap 'rm -rf "$test_root"' EXIT
+trap 'exit 129' HUP
+trap 'exit 130' INT
+trap 'exit 143' TERM
+
+fail() {
+  printf 'FAIL: %s\n' "$1" >&2
+  exit 1
+}
+
+command -v gitleaks >/dev/null 2>&1 || fail 'gitleaks is not installed'
+
+git init -q "$test_root/repository"
+git -C "$test_root/repository" config user.name 'Gitleaks Hook Test'
+git -C "$test_root/repository" config user.email 'gitleaks-hook-test@example.com'
+
+local_hook="$test_root/repository/.git/hooks/pre-commit"
+local_hook_marker="$test_root/local-hook-ran"
+cat >"$local_hook" <<EOF
+#!/usr/bin/env bash
+printf 'ran\n' >>'$local_hook_marker'
+EOF
+chmod +x "$local_hook"
+
+printf 'safe content\n' >"$test_root/repository/example.txt"
+git -C "$test_root/repository" add example.txt
+git -C "$test_root/repository" -c core.hooksPath="$hook_path" \
+  commit -q -m 'test: allow safe commit' || fail 'safe commit was rejected'
+[ "$(wc -l <"$local_hook_marker")" -eq 1 ] || fail 'repo-local hook was not delegated to'
+
+dummy_secret=$(printf '%s%s' 'ghp_' 'Zx7Qa2Wm9Lp4Ks8Hd3Jf6Ng1Bc5Vr0TyUiEo')
+printf 'token = "%s"\n' "$dummy_secret" >"$test_root/repository/secret.txt"
+git -C "$test_root/repository" add secret.txt
+if output=$(git -C "$test_root/repository" -c core.hooksPath="$hook_path" \
+  commit -m 'test: reject secret' 2>&1); then
+  fail 'commit containing a known-format dummy secret was accepted'
+fi
+case "$output" in
+  *"$dummy_secret"*) fail 'gitleaks output exposed the detected secret' ;;
+esac
+[ "$(wc -l <"$local_hook_marker")" -eq 1 ] || fail 'repo-local hook ran after gitleaks failed'
+git -C "$test_root/repository" diff --cached --quiet -- secret.txt && \
+  fail 'rejected secret was not left staged'
+
+printf 'Gitleaks pre-commit hook tests passed.\n'


### PR DESCRIPTION
close #389

## 目的

global pre-commit hook を秘密情報の commit 前検知に集中させ、ShellCheck などの品質チェックは既存の GitHub Actions に一本化します。あわせて、hook の回避やローカル環境差を補完する gitleaks の PR チェックを追加します。

## 変更内容

- `packages/git/.git-hooks/pre-commit` を公式の現行形式 `gitleaks git --pre-commit --redact --staged --verbose` へ更新
- global hook から staged Shell Script の ShellCheck を撤去し、既存の PR workflow を維持
- repo-local pre-commit hook への既存委譲を維持
- `.github/workflows/gitleaks.yml` で gitleaks 8.30.1 を checksum 検証付きで導入し、Git 履歴を検査
- `tests/gitleaks-pre-commit.sh` で通常 commit、ダミー secret の拒否、redact、repo-local hook 委譲、`--no-verify` 後の CI 相当検知を自動確認

## 影響範囲

- `packages/git/.git-hooks/pre-commit`
- `.github/workflows/gitleaks.yml`
- `tests/gitleaks-pre-commit.sh`

Git LFS、`core.hooksPath`、既存 ShellCheck / Prettier / actionlint / test workflow には変更していません。

## 検証

- `./tests/gitleaks-pre-commit.sh`
- `make test`
- `actionlint`
- `shellcheck packages/git/.git-hooks/pre-commit tests/gitleaks-pre-commit.sh tests/shell-scripts.sh`
- `NPM_CONFIG_CACHE=<temporary-directory> npx prettier@3 --check .`
- `gitleaks git --redact --verbose`
