### PR TITLE
refactor: ブラウザ操作をagent-browserへ一本化する

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -54,9 +54,6 @@ Use `make` targets as the standard workflow:
 - `make stow-link`: `packages/` 配下を `$HOME` にシンボリックリンク化。
 - `make stow-unlink`: Stow 管理のシンボリックリンクを削除。
 - `make mise-install`: mise 管理の開発 CLI と Terraform をインストール。
-- `make mcp-setup`: Claude Code と Codex の MCP サーバーをセットアップ。
-
-MCP設定はStow管理対象の設定ファイルと衝突し得るため、`make install` には含めず明示的に実行する。
 
 Example: `make stow-link` after adding a new file under `packages/zsh/`.
 

--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,6 @@ CODEX_CONFIG_SUDO ?= sudo
 	gh-extensions-install gh-extensions-update \
 	gitalias-install gitalias-update \
 	vim-plugins-install vim-plugins-update bat-cache-build \
-	mcp-setup claude-mcp-setup codex-mcp-setup \
 	claude-permissions-promote \
 	codex-system-config-dry-run codex-system-config-install \
 	codex-system-config-check codex-system-config-verify
@@ -148,16 +147,6 @@ vim-plugins-update: vim-plugins-install ## 管理対象の Vim プラグイン�
 
 bat-cache-build: ## bat のテーマキャッシュを再構築
 	bat cache --build
-
-mcp-setup: claude-mcp-setup codex-mcp-setup ## AI coding agent の MCP サーバーを設定
-
-claude-mcp-setup: ## Claude Code の MCP サーバーを設定
-	@claude mcp get chrome-devtools >/dev/null 2>&1 || \
-		claude mcp add --scope user --transport stdio chrome-devtools -- npx chrome-devtools-mcp@latest
-
-codex-mcp-setup: ## Codex の MCP サーバーを設定
-	@codex mcp get chrome-devtools >/dev/null 2>&1 || \
-		codex mcp add chrome-devtools -- npx chrome-devtools-mcp@latest
 
 codex-system-config-dry-run: ## system configの適用内容または差分を表示
 	@CODEX_SHARED_CONFIG="$(CODEX_SHARED_CONFIG)" CODEX_SYSTEM_CONFIG="$(CODEX_SYSTEM_CONFIG)" \

--- a/README.md
+++ b/README.md
@@ -15,8 +15,6 @@ make install
 
 `install.sh` でHomebrewをbootstrapした後、Makefileの個別ターゲットを順番に実行する。Homebrewパッケージ、シンボリックリンク、mise管理ツール、agent skill、GitHub CLI拡張、GitAlias、Vimプラグイン、batテーマキャッシュをセットアップし、最後に `make doctor` で状態を検査する。
 
-MCP設定は各ツール自身の設定ファイルを更新するため、Stow管理との衝突を避けて一括セットアップから分離している。必要な場合は `make mcp-setup` を明示的に実行する。
-
 ### Codex設定
 
 複数マシンで共有するCodex設定は [`config/codex/config.toml`](./config/codex/config.toml) を正本とし、`/etc/codex/config.toml` へ導入する。新規セットアップまたは共有設定の更新時は、適用内容を確認してから導入・検証する。
@@ -56,7 +54,6 @@ make codex-system-config-verify
 | `make codex-system-config-install` | Codexの共有設定を `/etc/codex/config.toml` へ導入 |
 | `make codex-system-config-check`   | Codex共有設定を一時ディレクトリで非破壊検証       |
 | `make codex-system-config-verify`  | 導入後のCodex設定の代表値を診断                   |
-| `make mcp-setup`                   | Claude CodeとCodexのMCPサーバーを設定             |
 
 ## 詳細
 


### PR DESCRIPTION
close #391

## 目的

ブラウザ操作の標準構成を agent-browser に一本化し、Claude Code / Codex 向けの Chrome DevTools MCP 常設セットアップを dotfiles から撤去します。

## 変更内容

- `Makefile` から `mcp-setup`、`claude-mcp-setup`、`codex-mcp-setup` と関連する phony 宣言を削除
- `README.md` と `AGENTS.md` から標準 MCP セットアップの案内を削除
- agent-browser の mise 宣言、共有 skill、Claude / Codex の実行許可は維持
- 実環境に登録済みの MCP server を削除する migration は追加しない
- 代替 browser automation tool は追加しない

## 影響パス

- `Makefile`
- `README.md`
- `AGENTS.md`

## ローカル検証

- `make help`
- `npm_config_cache=/private/tmp/codex-npm-cache-391 npx prettier@3 --check .`
- `git ls-files -z '*.sh' | xargs -0 shellcheck`
- `actionlint -color`
- `make test`
- リポジトリ全体の `chrome-devtools-mcp` / `chrome-devtools` 参照が 0 件であることを確認
- agent-browser の mise / skill / Claude・Codex 実行許可が維持されていることを確認
