### PR TITLE
chore: GitHub CLIをGit credential helperに設定する

### DIFF
--- a/packages/git/.gitconfig
+++ b/packages/git/.gitconfig
@@ -73,3 +73,9 @@ branch = main
 	clean = git-lfs clean -- %f
 	smudge = git-lfs smudge -- %f
 	process = git-lfs filter-process
+[credential "https://github.com"]
+	helper =
+	helper = !/opt/homebrew/bin/gh auth git-credential
+[credential "https://gist.github.com"]
+	helper =
+	helper = !/opt/homebrew/bin/gh auth git-credential


### PR DESCRIPTION
## 目的

GitHub CLIの認証情報をGitのHTTPS操作でも利用できるよう、`github.com`と`gist.github.com`のcredential helperをdotfilesで管理します。

## 変更内容

- 既存のcredential helperをホスト単位でリセット
- Homebrewで導入した`gh auth git-credential`をhelperとして登録
- Intel Mac向けパスの互換性は対象外

## 検証

- `git config --file packages/git/.gitconfig --get-all credential.https://github.com.helper`
- `git config --file packages/git/.gitconfig --get-all credential.https://gist.github.com.helper`
- `git diff --check`
- `make test`