### PR TITLE
chore: add issue-discover skill

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,7 @@ AGENT_SKILLS := \
 	hirokisakabe/issuekit:acceptance-check \
 	hirokisakabe/issuekit:cross-review \
 	hirokisakabe/issuekit:issue-create \
+	hirokisakabe/issuekit:issue-discover \
 	hirokisakabe/issuekit:issue-dispatch \
 	hirokisakabe/issuekit:issue-implement \
 	hirokisakabe/issuekit:issue-investigate \


### PR DESCRIPTION
## Summary

- add the upstream `issue-discover` skill to the managed agent skill list
- make it available through `make skills-install` alongside the other issuekit skills

## Verification

- `make help`
- `make test`
- `npx prettier@3 --check .`
- Codex review: no findings