### PR TITLE
chore: manage bkmk CLI with mise

### DIFF
--- a/packages/mise/.config/mise/config.toml
+++ b/packages/mise/.config/mise/config.toml
@@ -4,6 +4,7 @@ python = "3.14.6"
 terraform = "1.15.8"
 "npm:aze-cli" = "0.5.4"
 "npm:agent-browser" = "0.31.1"
+"npm:@bkmk/cli" = "0.1.1"
 "npm:shirube" = { version = "1.3.1", allow_builds = ["better-sqlite3"] }
 "npm:socket" = "1.1.140"
 "pipx:drawio2pptx" = "0.0.2"


### PR DESCRIPTION
## Summary

- add `@bkmk/cli` to the mise-managed npm tools
- pin the CLI to version `0.1.1`

## Verification

- `make mise-install`
- `make test`
- `make help`
- `npx prettier@3 --check packages/mise/.config/mise/config.toml`
- `git diff --check`
- Codex review: no findings