### PR TITLE
chore: manage tascal CLI with mise

### DIFF
--- a/packages/mise/.config/mise/config.toml
+++ b/packages/mise/.config/mise/config.toml
@@ -7,6 +7,7 @@ terraform = "1.15.8"
 "npm:@bkmk/cli" = "0.1.1"
 "npm:shirube" = { version = "1.3.1", allow_builds = ["better-sqlite3"] }
 "npm:socket" = "1.1.140"
+"npm:tascal-cli" = "0.2.0"
 "pipx:drawio2pptx" = "0.0.2"
 "pipx:headroom-ai" = { version = "0.23.0", extras = "proxy" }
 "pipx:openhands" = { version = "1.16.0", uvx_args = "--python 3.12" }


### PR DESCRIPTION
## Summary

- add `tascal-cli` to the mise-managed npm tools
- pin the CLI to version `0.2.0`

## Verification

- `make mise-install`
- `make test`
- `make help`
- `npx prettier@3 --check packages/mise/.config/mise/config.toml`
- `git diff --check`
- `mise exec npm:tascal-cli@0.2.0 -- sh -c 'command -v tascal-cli'`\n- Codex review: no findings\n\n## Note\n\nThe published npm package exposes the binary as `tascal-cli`, although the upstream README examples use `tascal`.