### PR TITLE
feat: refine Atrium Library terminal theme

### DIFF
--- a/packages/bat/.config/bat/config
+++ b/packages/bat/.config/bat/config
@@ -1,2 +1,2 @@
---theme="Iceberg"
+--theme="ansi"
 --style="numbers,changes,header"

--- a/packages/git/.gitconfig
+++ b/packages/git/.gitconfig
@@ -34,24 +34,24 @@ hooksPath = ~/.git-hooks
 diffFilter = delta --color-only
 
 [delta]
-# Frosted Aqua palette
+# Atrium Library palette
 navigate = true
 line-numbers = true
-syntax-theme = base16
-minus-style = syntax "#f4dce2"
-minus-emph-style = syntax "#ebc0ca"
-plus-style = syntax "#dcefe7"
-plus-emph-style = syntax "#b9dfd0"
+syntax-theme = ansi
+minus-style = syntax "#f2e6e6"
+minus-emph-style = syntax "#e8d2d2"
+plus-style = syntax "#e8eee8"
+plus-emph-style = syntax "#d6e2d6"
 zero-style = syntax
-line-numbers-minus-style = "#b84f68"
-line-numbers-plus-style = "#3f8969"
-line-numbers-left-style = "#6d8496"
-line-numbers-right-style = "#6d8496"
-line-numbers-zero-style = "#6d8496"
-file-style = "#4c87c7" bold
-file-decoration-style = "#8abdd0" ul
-hunk-header-style = "#8076b3" bold
-hunk-header-decoration-style = "#8abdd0" box
+line-numbers-minus-style = "#945f5f"
+line-numbers-plus-style = "#687768"
+line-numbers-left-style = "#737a7e"
+line-numbers-right-style = "#737a7e"
+line-numbers-zero-style = "#737a7e"
+file-style = "#687078" bold
+file-decoration-style = "#cbd1d4" ul
+hunk-header-style = "#756d7a" bold
+hunk-header-decoration-style = "#cbd1d4" box
 
 [merge]
 conflictStyle = zdiff3

--- a/packages/lazygit/.config/lazygit/config.yml
+++ b/packages/lazygit/.config/lazygit/config.yml
@@ -1,24 +1,24 @@
-# Frosted Aqua palette
+# Atrium Library palette
 gui:
   theme:
     activeBorderColor:
-      - "#4c87c7"
+      - "#596166"
       - bold
     inactiveBorderColor:
-      - "#8abdd0"
+      - "#cbd1d4"
     optionsTextColor:
-      - "#5e9bd9"
+      - "#687078"
     selectedLineBgColor:
-      - "#c7eaf6"
+      - "#dce1e3"
     selectedRangeBgColor:
-      - "#b4dfed"
+      - "#cbd1d4"
     cherryPickedCommitBgColor:
-      - "#b9dfd0"
+      - "#d6e2d6"
     cherryPickedCommitFgColor:
-      - "#3f8969"
+      - "#687768"
     unstagedChangesColor:
-      - "#b84f68"
+      - "#945f5f"
     defaultFgColor:
-      - "#203b52"
+      - "#1f2326"
   authorColors:
-    "*": "#8076b3"
+    "*": "#756d7a"

--- a/packages/wezterm/.wezterm.lua
+++ b/packages/wezterm/.wezterm.lua
@@ -60,6 +60,7 @@ config.window_frame = {
 }
 
 config.use_fancy_tab_bar = false
+config.show_new_tab_button_in_tab_bar = false
 config.window_decorations = 'INTEGRATED_BUTTONS|RESIZE'
 config.tab_max_width = 44
 config.window_padding = {
@@ -104,6 +105,8 @@ config.front_end = 'WebGpu'
 config.freetype_load_flags = 'NO_HINTING'
 
 config.font_size = 13.0
+config.line_height = 1.08
+config.cell_width = 1.01
 config.scrollback_lines = 10000
 config.keys = {
   {

--- a/packages/zsh/.zshrc
+++ b/packages/zsh/.zshrc
@@ -43,18 +43,18 @@ alias gwr='cd $(git worktree list | head -1 | awk "{print \$1}")'
 # starship
 eval "$(starship init zsh)"
 
-# Frosted Aqua color palette
+# Atrium Library palette
 # eza
-export EZA_COLORS="di=1;38;2;76;135;199:ln=38;2;55;138;155:ex=38;2;63;137;105:fi=38;2;32;59;82:*.md=38;2;128;118;179:*.json=38;2;150;104;36:*.lock=38;2;109;132;150:*.toml=38;2;150;104;36:*.yml=38;2;150;104;36:*.yaml=38;2;150;104;36"
+export EZA_COLORS="di=1;38;2;89;97;102:ln=38;2;101;117;117:ex=38;2;104;119;104:fi=38;2;31;35;38:*.md=38;2;117;109;122:*.json=38;2;130;116;88:*.lock=38;2;115;122;126:*.toml=38;2;130;116;88:*.yml=38;2;130;116;88:*.yaml=38;2;130;116;88"
 
 # fzf
 export FZF_DEFAULT_OPTS="
   --border=rounded --preview-border=rounded --margin=1 --padding=1,2
-  --color=fg:#203b52,bg:#ddf4fa,hl:#4c87c7
-  --color=fg+:#12283a,bg+:#c7eaf6,hl+:#5e9bd9
-  --color=info:#3f8969,prompt:#8076b3,pointer:#b84f68
-  --color=marker:#966824,spinner:#378a9b,header:#4c87c7
-  --color=border:#8abdd0"
+  --color=fg:#1f2326,bg:#f7f8f8,hl:#687078
+  --color=fg+:#1f2326,bg+:#dce1e3,hl+:#596166
+  --color=info:#687768,prompt:#596166,pointer:#687078
+  --color=marker:#827458,spinner:#657575,header:#737a7e
+  --color=border:#cbd1d4"
 source <(fzf --zsh)
 
 # zoxide


### PR DESCRIPTION
## 概要

Atrium Library の明るく低彩度な見た目を、ターミナル周辺ツール全体へ広げます。

- WezTerm の行間と字幅を少し広げ、new tab ボタンを非表示化
- fzf / eza / lazygit / delta の配色を Atrium Library パレットへ統一
- bat / delta の syntax theme を `ansi` にし、WezTerm の ANSI パレットを正本化
- タブバーは1タブ時も従来どおり表示

Yazi の Frosted Aqua テーマは今回の確認範囲外のため変更していません。

## 変更パス

- `packages/wezterm/.wezterm.lua`
- `packages/zsh/.zshrc`
- `packages/lazygit/.config/lazygit/config.yml`
- `packages/git/.gitconfig`
- `packages/bat/.config/bat/config`

## 確認

- ユーザーによる実環境での見た目確認
- `git diff --check`
- `zsh -n packages/zsh/.zshrc`
- WezTerm config load
- lazygit config load
- bat / delta の `ansi` theme 読み込み
- `npx prettier@3 --check .`
- `make help`
- gitleaks pre-commit hook
- cross-review（重大な指摘なし）