### PR TITLE
feat: add UI critique skills

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,11 @@ AGENT_SKILLS := \
 	anthropics/skills:frontend-design \
 	anthropics/skills:skill-creator \
 	jakubkrehel/make-interfaces-feel-better:make-interfaces-feel-better \
+	Owl-Listener/designer-skills:visual-critique/skills/critique-affordance \
+	Owl-Listener/designer-skills:visual-critique/skills/critique-composition \
+	Owl-Listener/designer-skills:visual-critique/skills/critique-information-density \
+	Owl-Listener/designer-skills:visual-critique/skills/critique-visual-hierarchy \
+	Owl-Listener/designer-skills:designer-toolkit/skills/ux-writing \
 	vercel-labs/agent-browser:agent-browser
 
 AGENT_SKILLS_DIR ?= $(HOME)/.agents/skills

--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ make codex-system-config-verify
 
 `make skills-update` は `~/.agents/skills` を明示して、共通配置されたskillを更新する。
 
+`AGENT_SKILLS` には `owner/repo:skill-name` に加えて、`owner/repo:path/to/skill` 形式でリポジトリ内のnested skillも指定できる。
+
 ## 主要コマンド
 
 | Command                            | 用途                                              |

--- a/scripts/skills-install.sh
+++ b/scripts/skills-install.sh
@@ -10,7 +10,7 @@ is_managed_skill() {
   local skill_file_path expected_repository expected_skill_path
   skill_file_path="$1/SKILL.md"
   expected_repository="https://github.com/$2"
-  expected_skill_path="skills/$3"
+  expected_skill_path="$3"
   [ -f "$skill_file_path" ] || return 1
   awk -v expected_repository="$expected_repository" -v expected_skill_path="$expected_skill_path" '
     NR == 1 { if ($0 != "---") exit 1; frontmatter = 1; next }
@@ -33,24 +33,29 @@ mkdir -p "$AGENT_SKILLS_DIR" "$CLAUDE_SKILLS_DIR"
 
 for skill_spec in "$@"; do
   repository=${skill_spec%:*}
-  skill=${skill_spec#*:}
+  skill_source=${skill_spec#*:}
+  skill=${skill_source##*/}
+  case "$skill_source" in
+    */*) expected_skill_path="$skill_source" ;;
+    *) expected_skill_path="skills/$skill_source" ;;
+  esac
   canonical_path="$AGENT_SKILLS_DIR/$skill"
   claude_path="$CLAUDE_SKILLS_DIR/$skill"
   codex_path="$CODEX_SKILLS_DIR/$skill"
 
   if [ -L "$canonical_path" ]; then
-    if is_managed_skill "$canonical_path" "$repository" "$skill"; then
+    if is_managed_skill "$canonical_path" "$repository" "$expected_skill_path"; then
       rm -f "$canonical_path"
     else
       printf '%s\n' "管理外の symlink と競合しています: $canonical_path" >&2
       exit 1
     fi
-  elif [ -e "$canonical_path" ] && ! is_managed_skill "$canonical_path" "$repository" "$skill"; then
+  elif [ -e "$canonical_path" ] && ! is_managed_skill "$canonical_path" "$repository" "$expected_skill_path"; then
     printf '%s\n' "管理外の既存 skill と競合しています: $canonical_path" >&2
     exit 1
   fi
 
-  gh skill install "$repository" "$skill" --dir "$AGENT_SKILLS_DIR" -f
+  gh skill install "$repository" "$skill_source" --dir "$AGENT_SKILLS_DIR" -f
 
   if [ -L "$claude_path" ]; then
     target=$(readlink "$claude_path")
@@ -58,13 +63,13 @@ for skill_spec in "$@"; do
       :
     elif [ ! -e "$claude_path" ]; then
       printf '%s\n' "既存の壊れた外部 symlink を保持します: $claude_path -> $target"
-    elif is_managed_skill "$claude_path" "$repository" "$skill"; then
+    elif is_managed_skill "$claude_path" "$repository" "$expected_skill_path"; then
       rm -f "$claude_path"
     else
       printf '%s\n' "既存の外部 symlink を保持します: $claude_path -> $target"
     fi
   elif [ -e "$claude_path" ]; then
-    if is_managed_skill "$claude_path" "$repository" "$skill"; then
+    if is_managed_skill "$claude_path" "$repository" "$expected_skill_path"; then
       rm -rf "$claude_path"
     else
       printf '%s\n' "管理外の既存 skill を保持します: $claude_path"
@@ -82,13 +87,13 @@ for skill_spec in "$@"; do
 
   if [ -L "$codex_path" ]; then
     target=$(readlink "$codex_path")
-    if [ -e "$codex_path" ] && { [ "$codex_path" -ef "$canonical_path" ] || is_managed_skill "$codex_path" "$repository" "$skill"; }; then
+    if [ -e "$codex_path" ] && { [ "$codex_path" -ef "$canonical_path" ] || is_managed_skill "$codex_path" "$repository" "$expected_skill_path"; }; then
       rm -f "$codex_path"
     else
       printf '%s\n' "既存の外部 symlink を保持します: $codex_path -> $target"
     fi
   elif [ -e "$codex_path" ]; then
-    if is_managed_skill "$codex_path" "$repository" "$skill"; then
+    if is_managed_skill "$codex_path" "$repository" "$expected_skill_path"; then
       rm -rf "$codex_path"
     else
       printf '%s\n' "管理外の既存 skill を保持します: $codex_path"

--- a/tests/shell-scripts.sh
+++ b/tests/shell-scripts.sh
@@ -28,14 +28,19 @@ test_skills_install() {
 #!/usr/bin/env bash
 set -euo pipefail
 repository=$3
-skill=$4
+skill_source=$4
+skill=${skill_source##*/}
 directory=$6
+case "$skill_source" in
+  */*) skill_path="$skill_source" ;;
+  *) skill_path="skills/$skill_source" ;;
+esac
 mkdir -p "$directory/$skill"
 cat >"$directory/$skill/SKILL.md" <<SKILL
 ---
 metadata:
     github-repo: https://github.com/$repository
-    github-path: skills/$skill
+    github-path: $skill_path
     github-tree-sha: 0123456789abcdef0123456789abcdef01234567
 ---
 SKILL
@@ -44,12 +49,20 @@ EOF
 
   make -s -C "$repo_root" skills-install \
     HOME="$home" PATH="$bin_dir:$PATH" \
-    AGENT_SKILLS='owner/repo:example' \
+    AGENT_SKILLS='owner/repo:example owner/repo:collection/skills/nested-example' \
     AGENT_SKILLS_DIR="$home/.agents/skills" \
     CLAUDE_SKILLS_DIR="$home/.claude/skills" \
     CODEX_SKILLS_DIR="$home/.codex/skills"
   [ -f "$home/.agents/skills/example/SKILL.md" ] || fail 'skill was not installed'
+  [ -f "$home/.agents/skills/nested-example/SKILL.md" ] || fail 'nested skill was not installed'
   [ -L "$home/.claude/skills/example" ] || fail 'Claude skill link was not created'
+  [ -L "$home/.claude/skills/nested-example" ] || fail 'nested Claude skill link was not created'
+
+  HOME="$home" PATH="$bin_dir:$PATH" \
+    AGENT_SKILLS_DIR="$home/.agents/skills" \
+    CLAUDE_SKILLS_DIR="$home/.claude/skills" \
+    CODEX_SKILLS_DIR="$home/.codex/skills" \
+    "$repo_root/scripts/skills-install.sh" owner/repo:collection/skills/nested-example
 
   mkdir -p "$home/.agents/skills/unmanaged"
   printf 'unmanaged\n' >"$home/.agents/skills/unmanaged/SKILL.md"


### PR DESCRIPTION
## Summary

- add four focused visual critique skills from Owl-Listener/designer-skills
- add the UX writing skill from the same repository
- support exact nested skill paths in the shared skill installer
- cover nested-path installation and repeat updates in shell tests

## Verification

- `make test`
- `make help`
- `npx prettier@3 --check .`
- installed all five skills twice into isolated temporary directories using the real `gh skill` CLI