### PR TITLE
feat: refine wezterm tab appearance

### DIFF
--- a/packages/wezterm/.wezterm.lua
+++ b/packages/wezterm/.wezterm.lua
@@ -65,7 +65,6 @@ config.window_frame = {
 config.use_fancy_tab_bar = true
 config.show_new_tab_button_in_tab_bar = false
 config.window_decorations = 'INTEGRATED_BUTTONS|RESIZE'
-config.tab_max_width = 44
 config.window_padding = {
   left = 16,
   right = 16,
@@ -75,7 +74,6 @@ config.window_padding = {
 
 config.colors = {
   tab_bar = {
-    background = surface,
     active_tab = {
       bg_color = background,
       fg_color = foreground,

--- a/packages/wezterm/.wezterm.lua
+++ b/packages/wezterm/.wezterm.lua
@@ -7,10 +7,11 @@ if wezterm.config_builder then
 end
 
 local background = '#f7f8f8'
-local surface = '#eceff0'
+local surface = '#e8ebec'
 local foreground = '#1f2326'
 local muted = '#737a7e'
 local accent = '#1f2326'
+local border = '#cbd1d4'
 
 -- Atrium Library: cool architectural whites, black details, and open space.
 config.color_schemes = {
@@ -54,12 +55,14 @@ config.font = wezterm.font_with_fallback {
 
 config.window_frame = {
   font = wezterm.font { family = "OverpassM Nerd Font" },
-  font_size = 15.0,
+  font_size = 13.0,
   active_titlebar_bg = surface,
   inactive_titlebar_bg = surface,
+  active_titlebar_border_bottom = border,
+  inactive_titlebar_border_bottom = border,
 }
 
-config.use_fancy_tab_bar = false
+config.use_fancy_tab_bar = true
 config.show_new_tab_button_in_tab_bar = false
 config.window_decorations = 'INTEGRATED_BUTTONS|RESIZE'
 config.tab_max_width = 44
@@ -83,7 +86,7 @@ config.colors = {
       fg_color = muted,
     },
     inactive_tab_hover = {
-      bg_color = '#dfe3e5',
+      bg_color = '#dde1e3',
       fg_color = foreground,
     },
     new_tab = {
@@ -91,7 +94,7 @@ config.colors = {
       fg_color = muted,
     },
     new_tab_hover = {
-      bg_color = '#dfe3e5',
+      bg_color = '#dde1e3',
       fg_color = foreground,
     },
   },


### PR DESCRIPTION
## 概要

WezTerm のタブを、現在の Atrium Library テーマに馴染む Chrome 風の表示へ調整します。

## 変更内容

- fancy tab bar を有効化
- タブ文字サイズを 13pt に調整
- active / inactive タブのコントラストを改善
- タイトルバー下端に境界色を追加
- fancy モードで無効になる retro 専用設定を削除

## 変更パス

- `packages/wezterm/.wezterm.lua`

## 確認内容

- `wezterm --config-file packages/wezterm/.wezterm.lua show-keys --lua`
- `make help`
- `npx prettier@3 --check .`
- `git diff --check`
- WezTerm 上でタブの active / inactive 状態とサイズを目視確認
- cross-review: critical 0 / warning 0